### PR TITLE
Add HTTP (streamable) mode and shared deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ An MCP (Model Context Protocol) server for [Nightingale](https://github.com/ccfo
 
 ### 2. Configure MCP Client
 
-#### Cursor
+#### Cursor (stdio mode, default)
 
 Add to your `~/.cursor/mcp.json`:
 
@@ -56,6 +56,67 @@ Add to your `~/.cursor/mcp.json`:
   }
 }
 ```
+
+#### HTTP mode (optional)
+
+To run the server over HTTP (MCP streamable transport, JSON only, no SSE), start the server with the `http` subcommand.
+
+**Shared vs non-shared (HTTP only):**
+
+- **`--shared=false`** (default): Token and base URL may be omitted at startup. Each client can provide `X-User-Token` and `X-N9e-Base-Url` in mcp.json so everyone uses their own Nightingale identity or instance. If you do set `N9E_TOKEN` and `N9E_BASE_URL` at startup, they act as defaults and clients can still override via headers.
+- **`--shared=true`**: Startup **must** set `N9E_TOKEN` and `N9E_BASE_URL`. The server uses only this config; client headers `X-User-Token` and `X-N9e-Base-Url` are **ignored**. Use this when the MCP server is a shared org service and users must not override credentials.
+
+```bash
+# Non-shared: users supply token/URL in mcp.json (or you set defaults at startup)
+n9e-mcp-server http --listen :8080
+
+# Shared: one token/URL for all; require at startup, ignore client headers
+N9E_TOKEN=xxx N9E_BASE_URL=https://n9e.example.com n9e-mcp-server http --listen :8080 --shared
+```
+
+**Cursor: connect to HTTP server**
+
+If the server is already running in HTTP mode (e.g. on `http://localhost:8080`), add a URL-based entry to `~/.cursor/mcp.json` (no `command`/`args`; Cursor will use the streamable HTTP transport).
+
+**Token:** You can use either source; you do **not** need to pass token in mcp.json if the server was started with `N9E_TOKEN`.
+
+1. **Server startup only** – Set `N9E_TOKEN` when starting the server (e.g. `N9E_TOKEN=xxx ./n9e-mcp-server http`). All clients will use this token; no headers needed in Cursor.
+2. **Client headers (optional)** – The client can send:
+   - `X-User-Token`: use this token for N9e API calls instead of the startup token.
+   - `X-N9e-Base-Url`: use this URL as the Nightingale API base (e.g. `https://n9e.other-env.com`) instead of the server's `N9E_BASE_URL`.
+   So each user can point to a different Nightingale instance or use their own token (or both).
+
+Example when the server **was** started with `N9E_TOKEN` (no header needed in Cursor):
+
+```json
+{
+  "mcpServers": {
+    "nightingale": {
+      "url": "http://localhost:8080"
+    }
+  }
+}
+```
+
+Example when passing token and/or base URL from Cursor (e.g. shared server, or different Nightingale instance):
+
+```json
+{
+  "mcpServers": {
+    "nightingale": {
+      "url": "http://localhost:8080",
+      "headers": {
+        "X-User-Token": "your-nightingale-api-token",
+        "X-N9e-Base-Url": "http://your-n9e-server:17000"
+      }
+    }
+  }
+}
+```
+
+You can omit either header: only `X-User-Token`, or only `X-N9e-Base-Url`, or both. The server falls back to startup `N9E_TOKEN` and `N9E_BASE_URL` when a header is not set. **If the server was started with `--shared`**, these headers are ignored and you must not rely on them.
+
+If your HTTP server is behind a gateway that requires its own auth, add those headers as well (e.g. `Authorization: Bearer your-gateway-token`). The server uses the `X-User-Token` header only for calling the Nightingale API.
 
 ### 3. Restart Cursor or Other Client Processes to Use
 
@@ -105,6 +166,11 @@ Once configured, you can interact with Nightingale using natural language:
 
 ## Configuration
 
+### Modes
+
+- **stdio** (default): MCP over stdin/stdout. Use with Cursor and other clients that spawn the server process.
+- **http**: MCP over HTTP using the streamable transport (JSON request/response only, no SSE). Use `n9e-mcp-server http` and connect with a client that supports streamable HTTP (e.g. `StreamableClientTransport`).
+
 ### Environment Variables
 
 | Variable | Flag | Description | Default |
@@ -113,6 +179,8 @@ Once configured, you can interact with Nightingale using natural language:
 | `N9E_BASE_URL` | `--base-url` | Nightingale API base URL | `http://localhost:17000` |
 | `N9E_READ_ONLY` | `--read-only` | Disable write operations | `false` |
 | `N9E_TOOLSETS` | `--toolsets` | Enabled toolsets (comma-separated) | `all` |
+| `N9E_LISTEN` | `--listen` | HTTP mode: listen address | `:8080` |
+| `N9E_SESSION_TIMEOUT` | `--session-timeout` | HTTP mode: idle session timeout (0 = no timeout) | `0` |
 
 ### Toolsets
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -37,7 +37,7 @@
 
 ### 2.与 MCP 客户端配合使用
 
-#### Cursor
+#### Cursor（stdio 模式，默认）
 
 在 `~/.cursor/mcp.json` 中添加：
 
@@ -55,6 +55,67 @@
   }
 }
 ```
+
+#### HTTP 模式（可选）
+
+以 HTTP 方式运行服务端（MCP streamable 传输，仅 JSON，无 SSE）时，使用 `http` 子命令启动。
+
+**共享模式 vs 非共享（仅 HTTP）：**
+
+- **`--shared=false`**（默认）：启动时可不提供 token 和 base URL。每个客户端在 mcp.json 里通过 `X-User-Token`、`X-N9e-Base-Url` 提供自己的夜莺身份或实例；若启动时设置了 `N9E_TOKEN` 和 `N9E_BASE_URL`，则作为默认值，客户端仍可通过 header 覆盖。
+- **`--shared=true`**：启动时**必须**设置 `N9E_TOKEN` 和 `N9E_BASE_URL`。服务端仅使用该配置，**忽略**客户端请求头中的 `X-User-Token` 和 `X-N9e-Base-Url`。适用于组织统一提供的 MCP 服务、不允许用户覆盖凭证的场景。
+
+```bash
+# 非共享：由用户在 mcp.json 提供 token/URL（或启动时设默认值）
+n9e-mcp-server http --listen :8080
+
+# 共享：统一凭证，启动时必填，忽略客户端 header
+N9E_TOKEN=xxx N9E_BASE_URL=https://n9e.example.com n9e-mcp-server http --listen :8080 --shared
+```
+
+**Cursor 连接 HTTP 服务端**
+
+若服务端已以 HTTP 模式运行（例如在 `http://localhost:8080`），在 `~/.cursor/mcp.json` 中添加以 URL 方式配置的条目（无需 `command`/`args`，Cursor 会使用 streamable HTTP 传输）。
+
+**Token 传递**：二选一即可，不必在 mcp.json 里传 token（只要服务端启动时配了 `N9E_TOKEN`）。
+
+1. **仅服务端启动时**：启动时设置 `N9E_TOKEN`（如 `N9E_TOKEN=xxx ./n9e-mcp-server http`），所有连接该服务的客户端都会用这个 token，Cursor 里**无需**配置任何 header。
+2. **客户端请求头（可选）**：可携带：
+   - `X-User-Token`：用该 token 调夜莺 API，替代启动时的 `N9E_TOKEN`；
+   - `X-N9e-Base-Url`：用该 URL 作为夜莺 API 地址（如 `https://n9e.other-env.com`），替代服务端启动时的 `N9E_BASE_URL`。
+   这样每人可使用自己的 token 或指向不同夜莺环境（或同时覆盖两者）。
+
+若服务端**已用** `N9E_TOKEN` 启动（Cursor 里不必写 header）：
+
+```json
+{
+  "mcpServers": {
+    "nightingale": {
+      "url": "http://localhost:8080"
+    }
+  }
+}
+```
+
+若由 Cursor 通过请求头传 token 和/或夜莺地址（例如服务未设 `N9E_TOKEN`、或连到不同夜莺环境时）：
+
+```json
+{
+  "mcpServers": {
+    "nightingale": {
+      "url": "http://localhost:8080",
+      "headers": {
+        "X-User-Token": "你的夜莺-api-token",
+        "X-N9e-Base-Url": "http://your-n9e-server:17000"
+      }
+    }
+  }
+}
+```
+
+可只写其中一个 header；未写的项会使用服务端启动时的 `N9E_TOKEN` / `N9E_BASE_URL`。**若服务端以 `--shared` 启动，则这些 header 会被忽略，请勿依赖。**
+
+若 MCP 服务前还有网关等需要认证，可同时配置对应 headers（如 `Authorization: Bearer your-gateway-token`）。服务端仅用 `X-User-Token` 作为调用夜莺 API 的凭证。
 
 ### 3.重启 Cursor 等进程，即可使用
 
@@ -104,6 +165,11 @@
 
 ## 配置
 
+### 运行模式
+
+- **stdio**（默认）：通过 stdin/stdout 进行 MCP 通信。适用于 Cursor 等会拉起服务进程的客户端。
+- **http**：通过 HTTP 使用 MCP streamable 传输（仅 JSON 请求/响应，无 SSE）。使用 `n9e-mcp-server http` 启动，客户端需支持 streamable HTTP（如 `StreamableClientTransport`）。
+
 ### 环境变量
 
 | 变量 | 命令行参数 | 说明 | 默认值 |
@@ -112,6 +178,9 @@
 | `N9E_BASE_URL` | `--base-url` | 夜莺 API 地址 | `http://localhost:17000` |
 | `N9E_READ_ONLY` | `--read-only` | 禁用写操作 | `false` |
 | `N9E_TOOLSETS` | `--toolsets` | 启用的工具集（逗号分隔） | `all` |
+| `N9E_LISTEN` | `--listen` | HTTP 模式：监听地址 | `:8080` |
+| `N9E_SESSION_TIMEOUT` | `--session-timeout` | HTTP 模式：空闲会话超时（0 表示不超时） | `0` |
+| `N9E_SHARED` | `--shared` | HTTP 模式：为 true 时启动必须提供 N9E_TOKEN 和 N9E_BASE_URL，并忽略客户端 header | `false` |
 
 ### 工具集选择
 

--- a/cmd/n9e-mcp-server/main.go
+++ b/cmd/n9e-mcp-server/main.go
@@ -42,6 +42,13 @@ var stdioCmd = &cobra.Command{
 	RunE:  runStdio,
 }
 
+var httpCmd = &cobra.Command{
+	Use:   "http",
+	Short: "Run in HTTP mode (streamable transport, JSON only, no SSE)",
+	Long:  "Run the MCP server over HTTP. Uses MCP streamable transport with application/json request/response (no server-sent events).",
+	RunE:  runHTTP,
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
@@ -70,8 +77,17 @@ func init() {
 	viper.BindPFlag("read_only", rootCmd.PersistentFlags().Lookup("read-only"))
 	viper.BindPFlag("log_file", rootCmd.PersistentFlags().Lookup("log-file"))
 
+	// HTTP-specific flags
+	httpCmd.Flags().String("listen", ":8080", "Listen address (env: N9E_LISTEN)")
+	httpCmd.Flags().Duration("session-timeout", 0, "Idle session timeout (0 = no timeout, env: N9E_SESSION_TIMEOUT)")
+	httpCmd.Flags().Bool("shared", false, "Shared mode: require N9E_TOKEN and N9E_BASE_URL at startup, ignore client headers (env: N9E_SHARED)")
+	viper.BindPFlag("listen", httpCmd.Flags().Lookup("listen"))
+	viper.BindPFlag("session_timeout", httpCmd.Flags().Lookup("session-timeout"))
+	viper.BindPFlag("shared", httpCmd.Flags().Lookup("shared"))
+
 	// Add subcommands
 	rootCmd.AddCommand(stdioCmd)
+	rootCmd.AddCommand(httpCmd)
 	rootCmd.AddCommand(versionCmd)
 }
 
@@ -88,5 +104,29 @@ func runStdio(cmd *cobra.Command, args []string) error {
 		EnabledToolsets: viper.GetStringSlice("toolsets"),
 		ReadOnly:        viper.GetBool("read_only"),
 		LogFilePath:     viper.GetString("log_file"),
+	})
+}
+
+func runHTTP(cmd *cobra.Command, args []string) error {
+	shared := viper.GetBool("shared")
+	token := viper.GetString("token")
+	baseURL := viper.GetString("base_url")
+
+	if shared {
+		if token == "" || baseURL == "" {
+			return fmt.Errorf("when --shared is true, N9E_TOKEN and N9E_BASE_URL are required")
+		}
+	}
+
+	return internal.RunHTTPServer(internal.HTTPServerConfig{
+		Version:         version,
+		Token:           token,
+		BaseURL:         baseURL,
+		EnabledToolsets: viper.GetStringSlice("toolsets"),
+		ReadOnly:        viper.GetBool("read_only"),
+		LogFilePath:     viper.GetString("log_file"),
+		ListenAddr:      viper.GetString("listen"),
+		SessionTimeout:  viper.GetDuration("session_timeout"),
+		Shared:          shared,
 	})
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -5,8 +5,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/n9e/n9e-mcp-server/pkg/api"
 	"github.com/n9e/n9e-mcp-server/pkg/client"
@@ -14,6 +20,13 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// Header names for Nightingale API when passed from MCP client (e.g. Cursor).
+// When set, they override the server's startup N9E_TOKEN / N9E_BASE_URL for that session.
+const (
+	N9eTokenHeader  = "X-User-Token"
+	N9eBaseURLHeader = "X-N9e-Base-Url"
 )
 
 // ServerConfig represents MCP Server configuration
@@ -160,6 +173,212 @@ func RunStdioServer(cfg StdioServerConfig) error {
 	select {
 	case <-ctx.Done():
 		logger.Info("shutting down server...")
+	case err := <-errC:
+		if err != nil {
+			logger.Error("server error", "error", err)
+			return fmt.Errorf("server error: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// HTTPServerConfig represents HTTP mode configuration.
+type HTTPServerConfig struct {
+	Version         string
+	Token           string
+	BaseURL         string
+	EnabledToolsets []string
+	ReadOnly        bool
+	LogFilePath     string
+	ListenAddr      string        // e.g. ":8080" or "0.0.0.0:8080"
+	SessionTimeout  time.Duration // zero means no idle timeout
+	// Shared: when true, server must be started with N9E_TOKEN and N9E_BASE_URL; client headers (X-User-Token, X-N9e-Base-Url) are ignored.
+	// When false, token and base URL may be omitted at startup; each request must provide them via headers (mcp.json).
+	Shared bool
+}
+
+// RunHTTPServer runs the MCP server over HTTP using the streamable transport.
+// It uses JSON request/response only (no SSE). Each request is handled via
+// standard HTTP POST; session state is maintained via Mcp-Session-Id header.
+func RunHTTPServer(cfg HTTPServerConfig) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	var logOutput io.Writer = os.Stderr
+	if cfg.LogFilePath != "" {
+		logOutput = &lumberjack.Logger{
+			Filename:   cfg.LogFilePath,
+			MaxSize:    100,
+			MaxBackups: 3,
+			MaxAge:     7,
+			Compress:   true,
+		}
+	}
+
+	var logLevel slog.LevelVar
+	parseLogLevel := func() slog.Level {
+		switch os.Getenv("N9E_MCP_LOG_LEVEL") {
+		case "debug", "DEBUG":
+			return slog.LevelDebug
+		case "warn", "WARN":
+			return slog.LevelWarn
+		case "error", "ERROR":
+			return slog.LevelError
+		default:
+			return slog.LevelInfo
+		}
+	}
+	logLevel.Set(parseLogLevel())
+	logger := slog.New(slog.NewTextHandler(logOutput, &slog.HandlerOptions{Level: &logLevel}))
+	slog.SetDefault(logger)
+
+	setupSignalReload(func() {
+		newLevel := parseLogLevel()
+		logLevel.Set(newLevel)
+		logger.Info("log level reloaded", "level", newLevel.String())
+	})
+
+	listenAddr := cfg.ListenAddr
+	if listenAddr == "" {
+		listenAddr = ":8080"
+	}
+
+	// shared=true: require token and base URL at startup; client headers are ignored.
+	if cfg.Shared {
+		if cfg.Token == "" || cfg.BaseURL == "" {
+			return fmt.Errorf("when shared=true (HTTP), N9E_TOKEN and N9E_BASE_URL are required at startup")
+		}
+	}
+
+	logger.Info("starting n9e-mcp-server (HTTP)",
+		"version", cfg.Version,
+		"listen", listenAddr,
+		"shared", cfg.Shared,
+		"base_url", cfg.BaseURL,
+		"read_only", cfg.ReadOnly,
+		"toolsets", cfg.EnabledToolsets,
+	)
+
+	var getServerForRequest func(*http.Request) *mcp.Server
+
+	if cfg.Shared {
+		// Shared mode: single server from startup config; ignore X-User-Token and X-N9e-Base-Url.
+		defaultServer, err := NewMCPServer(ServerConfig{
+			Version:         cfg.Version,
+			Token:           cfg.Token,
+			BaseURL:         cfg.BaseURL,
+			EnabledToolsets: cfg.EnabledToolsets,
+			ReadOnly:        cfg.ReadOnly,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create MCP server: %w", err)
+		}
+		getServerForRequest = func(*http.Request) *mcp.Server { return defaultServer }
+	} else {
+		// Non-shared: token and base URL may be omitted at startup; each request must provide X-User-Token and X-N9e-Base-Url.
+		var defaultServer *mcp.Server
+		if cfg.Token != "" && cfg.BaseURL != "" {
+			var err error
+			defaultServer, err = NewMCPServer(ServerConfig{
+				Version:         cfg.Version,
+				Token:           cfg.Token,
+				BaseURL:         cfg.BaseURL,
+				EnabledToolsets: cfg.EnabledToolsets,
+				ReadOnly:        cfg.ReadOnly,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create default MCP server: %w", err)
+			}
+		}
+		var serverCache sync.Map // "token|baseURL" -> *mcp.Server
+		getServerForRequest = func(req *http.Request) *mcp.Server {
+			token := strings.TrimSpace(req.Header.Get(N9eTokenHeader))
+			baseURL := strings.TrimSpace(req.Header.Get(N9eBaseURLHeader))
+			if baseURL != "" {
+				if _, err := url.Parse(baseURL); err != nil {
+					logger.Warn("invalid X-N9e-Base-Url header", "value", baseURL, "error", err)
+					baseURL = ""
+				}
+			}
+			// No headers: use default server if startup provided token+baseURL; otherwise require headers.
+			if token == "" && baseURL == "" {
+				if defaultServer != nil {
+					return defaultServer
+				}
+				logger.Warn("request missing X-User-Token and X-N9e-Base-Url (shared=false, no startup config)")
+				return nil
+			}
+			if token == "" {
+				token = cfg.Token
+			}
+			if baseURL == "" {
+				baseURL = cfg.BaseURL
+			}
+			if token == "" || baseURL == "" {
+				logger.Warn("request missing X-User-Token or X-N9e-Base-Url (shared=false)")
+				return nil
+			}
+			cacheKey := token + "|" + baseURL
+			if s, ok := serverCache.Load(cacheKey); ok {
+				return s.(*mcp.Server)
+			}
+			s, err := NewMCPServer(ServerConfig{
+				Version:         cfg.Version,
+				Token:           token,
+				BaseURL:         baseURL,
+				EnabledToolsets: cfg.EnabledToolsets,
+				ReadOnly:        cfg.ReadOnly,
+			})
+			if err != nil {
+				logger.Warn("failed to create MCP server for request headers", "error", err)
+				if defaultServer != nil {
+					return defaultServer
+				}
+				return nil
+			}
+			serverCache.Store(cacheKey, s)
+			return s
+		}
+	}
+
+	// Streamable HTTP handler with JSON response only (no SSE).
+	opts := &mcp.StreamableHTTPOptions{
+		JSONResponse:   true,
+		Logger:         logger,
+		SessionTimeout: cfg.SessionTimeout,
+	}
+	handler := mcp.NewStreamableHTTPHandler(getServerForRequest, opts)
+
+	httpServer := &http.Server{
+		Addr:              listenAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+	}
+
+	errC := make(chan error, 1)
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errC <- err
+		} else {
+			errC <- nil
+		}
+	}()
+
+	logger.Info("Nightingale MCP Server (HTTP) listening", "addr", listenAddr)
+	fmt.Fprintf(os.Stderr, "Nightingale MCP Server (HTTP) listening on %s\n", listenAddr)
+
+	select {
+	case <-ctx.Done():
+		logger.Info("shutting down HTTP server...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("HTTP server shutdown error", "error", err)
+		}
 	case err := <-errC:
 		if err != nil {
 			logger.Error("server error", "error", err)


### PR DESCRIPTION
- **Add HTTP (streamable) mode**  
  New `http` subcommand runs the MCP server over HTTP using the go-sdk streamable transport with JSON-only request/response (no SSE). Implemented in `internal/server.go` via `RunHTTPServer`, using `mcp.NewStreamableHTTPHandler` and a standard `net/http.Server` with timeouts and graceful shutdown.
- **Per-request token and base URL overrides (non-shared HTTP)**  
  Clients (e.g. Cursor) can pass Nightingale credentials via headers: `X-User-Token` overrides `N9E_TOKEN`, `X-N9e-Base-Url` overrides `N9E_BASE_URL` (with basic URL validation). Servers are cached per `token|baseURL` so different users/environments don’t interfere.
- **`--shared` option for org-wide deployments**  
  When `--shared=true` (or `N9E_SHARED=true`): require `N9E_TOKEN` and `N9E_BASE_URL` at startup and ignore `X-User-Token` / `X-N9e-Base-Url`. When `--shared=false` (default): startup token/URL are optional and act as defaults; clients may override via headers.
- **Docs**  
  README (EN/ZH) updated with HTTP mode, shared vs non-shared, Cursor `mcp.json` examples, and new env vars (`N9E_LISTEN`, `N9E_SESSION_TIMEOUT`, `N9E_SHARED`).
## Test plan
- **Build**: `go build ./...`
- **Stdio**: Run `n9e-mcp-server` or `n9e-mcp-server stdio`; confirm existing MCP clients still work.
- **HTTP non-shared**: Start `n9e-mcp-server http --listen :8080`; in Cursor set `url` + `headers.X-User-Token` and `headers.X-N9e-Base-Url`; verify tools (e.g. `list_active_alerts`) hit the expected Nightingale instance.
- **HTTP shared**: Start `N9E_TOKEN=... N9E_BASE_URL=... n9e-mcp-server http --listen :8080 --shared`; confirm requests use startup config and that changing `X-User-Token` / `X-N9e-Base-Url` in mcp.json has no effect.
