### PR TITLE
feat: add docker deployment support and web platform compatibility via mcp-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,39 @@ Add to your `~/.cursor/mcp.json`:
 }
 ```
 
+#### Docker
+
+The official code uses the `stdio` protocol by default for inter-process communication. If you need to integrate with web-based LLM orchestration platforms like Dify or FastGPT that only support network calls (HTTP/SSE), we recommend using the provided Docker Compose solution. This deployment automatically introduces the `mcp-proxy` bridge to enable network protocol support.
+
+**Deployment Steps:**
+
+1. Clone this repository:
+
+   ```bash
+   git clone https://github.com/n9e/n9e-mcp-server.git
+   cd n9e-mcp-server/docker
+   ```
+   
+2. Modify the configuration in `docker-compose.yml`:
+
+   - `MCP_VERSION`: (Optional) Specify the version in `build.args`, e.g., `0.1.1`. Defaults to `latest` if left blank.
+   - `N9E_BASE_URL`: Replace with your actual Nightingale API URL.
+   - `N9E_TOKEN`: Replace with your generated API Token.
+
+3. Start the service:
+
+   ```bash
+   # By default, it will install the specified version via NPM and start
+   docker compose up -d --build
+   ```
+   
+4. Configure the MCP plugin in Dify:
+
+   - **Connection Type**: Streamable HTTP (SSE)
+   - **URL**: `http://<Your-Server-IP>:8082/sse`
+
+> **Developer Note**: If you have modified the source code and wish to build a local test image, change the `dockerfile` field in `docker-compose.yml` to `docker/Dockerfile.source`. This will automatically copy all source code and execute the complete local TS build process.
+
 ### 3. Restart Cursor or Other Client Processes to Use
 
 ## Available Tools

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The official code uses the `stdio` protocol by default for inter-process communi
    
 2. Modify the configuration in `docker-compose.yml`:
 
-   - `MCP_VERSION`: (Optional) Specify the version in `build.args`, e.g., `0.1.1`. Defaults to `latest` if left blank.
+   - `MCP_VERSION`: (Optional) Set this explicitly in `build.args` to `latest` or to a concrete version such as `0.1.1`. Do not leave it blank.
    - `N9E_BASE_URL`: Replace with your actual Nightingale API URL.
    - `N9E_TOKEN`: Replace with your generated API Token.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The official code uses the `stdio` protocol by default for inter-process communi
    - **Connection Type**: Streamable HTTP (SSE)
    - **URL**: `http://<Your-Server-IP>:8082/sse`
 
-> **Developer Note**: If you have modified the source code and wish to build a local test image, change the `dockerfile` field in `docker-compose.yml` to `docker/Dockerfile.source`. This will automatically copy all source code and execute the complete local TS build process.
+> **Developer Note**: If you have modified the source code and wish to build a local test image, change the `dockerfile` field in `docker-compose.yml` to `docker/Dockerfile.source`. This will copy the repository source into the image, run the project's normal Go build process (via the repository build/Makefile flow), and then start the server using the image's configured runtime entrypoint.
 
 ### 3. Restart Cursor or Other Client Processes to Use
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -71,7 +71,7 @@
 
 2. 修改 `docker-compose.yml` 中的配置：
 
-   - `MCP_VERSION`: (可选) 在 `build.args` 中指定版本号，如 `0.1.1`，留空或 `latest` 则拉取最新版。
+   - `MCP_VERSION`: (可选) 在 `build.args` 中显式指定版本号，如 `0.1.1`；如需拉取最新版，请填写 `latest`，不要留空。
    - `N9E_BASE_URL`: 替换为夜莺的实际 API 地址。
    - `N9E_TOKEN`: 替换为您生成的 API Token。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -56,6 +56,39 @@
 }
 ```
 
+#### Docker
+
+官方代码默认采用 `stdio` 协议进行进程间通信。若需要对接 Dify、FastGPT 等仅支持网络调用 (HTTP/SSE) 的大模型编排平台，推荐使用我们提供的 Docker Compose 方案。底层将自动引入 `mcp-proxy` 桥接器实现网络协议支持。
+
+**部署步骤：**
+
+1. 克隆本仓库到本地：
+
+   ```bash
+   git clone -b main https://github.com/n9e/n9e-mcp-server.git
+   cd n9e-mcp-server/docker
+   ```
+
+2. 修改 `docker-compose.yml` 中的配置：
+
+   - `MCP_VERSION`: (可选) 在 `build.args` 中指定版本号，如 `0.1.1`，留空或 `latest` 则拉取最新版。
+   - `N9E_BASE_URL`: 替换为夜莺的实际 API 地址。
+   - `N9E_TOKEN`: 替换为您生成的 API Token。
+
+3. 启动服务：
+
+   ```bash
+   # 默认将通过 NPM 安装指定版本的 MCP Server 并启动
+   docker compose up -d --build
+   ```
+
+4. 在 Dify 的 MCP 插件中配置：
+
+   - **连接方式**：基于 HTTP 的流式连接 (SSE)
+   - **URL**：`http://<您的服务器IP>:8082/sse`
+
+> **开发者说明**：若您修改了源代码并希望构建本地测试镜像，请在 `docker-compose.yml` 中将 `dockerfile` 字段修改为 `docker/Dockerfile.source`，它会自动拷贝所有源码并执行完整的本地 TS 编译流程。
+
 ### 3.重启 Cursor 等进程，即可使用
 
 ## 可用工具

--- a/README_zh.md
+++ b/README_zh.md
@@ -87,7 +87,7 @@
    - **连接方式**：基于 HTTP 的流式连接 (SSE)
    - **URL**：`http://<您的服务器IP>:8082/sse`
 
-> **开发者说明**：若您修改了源代码并希望构建本地测试镜像，请在 `docker-compose.yml` 中将 `dockerfile` 字段修改为 `docker/Dockerfile.source`，它会自动拷贝所有源码并执行完整的本地 TS 编译流程。
+> **开发者说明**：若您修改了源代码并希望构建本地测试镜像，请在 `docker-compose.yml` 中将 `dockerfile` 字段修改为 `docker/Dockerfile.source`。该 Dockerfile 会自动拷贝所有源码，执行 Go 项目的本地构建流程（如 `make build` 或 `go build`），并按镜像默认入口启动服务。
 
 ### 3.重启 Cursor 等进程，即可使用
 

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+dist

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,3 +1,3 @@
-node_modules
-.git
-dist
+# This file is not applied when Docker Compose uses the repository root (`..`)
+# as the build context. Move these ignore rules to `../.dockerignore` (or
+# change the build context) so `node_modules`, `.git`, and `dist` are excluded.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+# 定义变量：允许用户在 build 时传入指定的 NPM 版本号，默认为 latest
+ARG MCP_VERSION=latest
+
+# 设置淘宝源，并安装指定版本的夜莺 MCP 以及网络桥接器 mcp-proxy
+RUN npm config set registry https://registry.npmmirror.com && \
+    npm install -g @n9e/n9e-mcp-server@${MCP_VERSION} mcp-proxy
+
+EXPOSE 8082
+
+# 启动代理桥接器，并透传给全局安装的夜莺 MCP 模块
+CMD ["npx", "mcp-proxy", "--port", "8082", "--", "npx", "@n9e/n9e-mcp-server", "stdio"]

--- a/docker/Dockerfile.source
+++ b/docker/Dockerfile.source
@@ -1,0 +1,22 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+# 优先拷贝 package.json 利用 Docker 缓存
+COPY package*.json ./
+
+# 设置淘宝源并安装本地依赖
+RUN npm config set registry https://registry.npmmirror.com && \
+    npm install
+
+# 拷贝全量源码并编译 (TS -> JS)
+COPY . .
+RUN npm run build
+
+# 单独全局安装 mcp-proxy 桥接器
+RUN npm install -g mcp-proxy
+
+EXPOSE 8082
+
+# 启动代理桥接器，并执行本地编译后的代码
+CMD ["npx", "mcp-proxy", "--port", "8082", "--", "npm", "start"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   n9e-mcp-server:
     build: 
-      context: .. # 指向项目根目录作为构建上下文
-      dockerfile: docker/Dockerfile # 默认使用 NPM 安装模式
-      # dockerfile: docker/Dockerfile.source # 开发者可取消注释，使用源码编译模式
+      context: . # 使用 docker 目录作为构建上下文，确保 docker/.dockerignore 生效
+      dockerfile: Dockerfile # 默认使用 NPM 安装模式
+      # dockerfile: Dockerfile.source # 开发者可取消注释，使用源码编译模式
       args:
         # 指定需要的版本号，如 "0.1.1"。留空或 latest 则拉取最新版
         MCP_VERSION: "latest"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  n9e-mcp-server:
+    build: 
+      context: .. # 指向项目根目录作为构建上下文
+      dockerfile: docker/Dockerfile # 默认使用 NPM 安装模式
+      # dockerfile: docker/Dockerfile.source # 开发者可取消注释，使用源码编译模式
+      args:
+        # 指定需要的版本号，如 "0.1.1"。留空或 latest 则拉取最新版
+        MCP_VERSION: "latest"
+    container_name: n9e-mcp-server
+    restart: always
+    environment:
+      # 夜莺 API 地址 (必须配置)
+      N9E_BASE_URL: "http://your-n9e-server:17000"
+      # 夜莺 API Token (必须配置)
+      N9E_TOKEN: "your_n9e_api_token_here"
+      # 可选：通过环境变量控制启用的工具集
+      # N9E_TOOLSETS: "alerts,targets,mutes"
+    ports:
+      - "8082:8082"
+    # 增加资源限制，保障宿主机稳定性
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,8 +19,5 @@ services:
     ports:
       - "8082:8082"
     # 增加资源限制，保障宿主机稳定性
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 512M
+    cpus: '0.5'
+    mem_limit: 512M


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a complete Docker & Docker Compose deployment solution. 
By introducing `mcp-proxy`, it enables the MCP server to support HTTP/SSE protocols, making it fully compatible with Web-based LLM platforms like Dify and FastGPT, while keeping the default `stdio` behavior intact.

It also splits the Dockerfile into NPM-installation mode (for regular users) and source-build mode (for developers), and updates the English and Chinese documentation accordingly.

**Which issue(s) this PR fixes**:
Fixes #5