### PR TITLE
feat(docker): add Docker Compose deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.claude
+doc
+npm
+scripts
+README.md
+README_zh.md
+.goreleaser.yaml
+.gitignore
+opencode.json
+.mcp.json
+.env
+.env.*
+docker/.env
+docker/.env.*
+n9e-mcp-server

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.exe binary

--- a/README.md
+++ b/README.md
@@ -57,6 +57,39 @@ Add to your `~/.cursor/mcp.json`:
 }
 ```
 
+#### Docker
+
+The official code uses the `stdio` protocol by default for inter-process communication. If you need to integrate with web-based LLM orchestration platforms like Dify or FastGPT that only support network calls (HTTP/SSE), we recommend using the provided Docker Compose solution. This deployment automatically introduces the `mcp-proxy` bridge to enable network protocol support.
+
+**Deployment Steps:**
+
+1. Clone this repository:
+
+   ```bash
+   git clone https://github.com/n9e/n9e-mcp-server.git
+   cd n9e-mcp-server/docker
+   ```
+
+2. Modify the configuration in `docker-compose.yml`:
+
+   - `MCP_VERSION`: (Optional) Used by the default Dockerfile to install `@n9e/n9e-mcp-server` from NPM during image build. Set this explicitly to `latest` or to a concrete version such as `0.1.1`. Do not leave it blank.
+   - `N9E_BASE_URL`: Replace with your actual Nightingale API URL.
+   - `N9E_TOKEN`: Replace with your generated API Token.
+
+3. Start the service:
+
+   ```bash
+   # By default, it will install the specified version via NPM and start
+   docker compose up -d --build
+   ```
+
+4. Configure the MCP plugin in Dify:
+
+   - **Connection Type**: Streamable HTTP (SSE)
+   - **URL**: `http://<Your-Server-IP>:8082/sse`
+
+> **Developer Note**: If you have modified the source code and wish to build a local test image, change the `dockerfile` field in `docker-compose.yml` to `docker/Dockerfile.source`. This will copy the repository source into the image, build the Go server locally, and still start the server through the `mcp-proxy` bridge.
+
 ### 3. Restart Cursor or Other Client Processes to Use
 
 ## Available Tools

--- a/README_zh.md
+++ b/README_zh.md
@@ -56,6 +56,39 @@
 }
 ```
 
+#### Docker
+
+官方代码默认采用 `stdio` 协议进行进程间通信。若需要对接 Dify、FastGPT 等仅支持网络调用 (HTTP/SSE) 的大模型编排平台，推荐使用我们提供的 Docker Compose 方案。底层将自动引入 `mcp-proxy` 桥接器实现网络协议支持。
+
+**部署步骤：**
+
+1. 克隆本仓库到本地：
+
+   ```bash
+   git clone -b main https://github.com/n9e/n9e-mcp-server.git
+   cd n9e-mcp-server/docker
+   ```
+
+2. 修改 `docker-compose.yml` 中的配置：
+
+   - `MCP_VERSION`: (可选) 默认 Dockerfile 会在构建镜像时通过 NPM 安装 `@n9e/n9e-mcp-server`。请显式指定版本号，如 `0.1.1`；如需安装最新版，请填写 `latest`，不要留空。
+   - `N9E_BASE_URL`: 替换为夜莺的实际 API 地址。
+   - `N9E_TOKEN`: 替换为您生成的 API Token。
+
+3. 启动服务：
+
+   ```bash
+   # 默认将通过 NPM 安装指定版本的 MCP Server 并启动
+   docker compose up -d --build
+   ```
+
+4. 在 Dify 的 MCP 插件中配置：
+
+   - **连接方式**：基于 HTTP 的流式连接 (SSE)
+   - **URL**：`http://<您的服务器IP>:8082/sse`
+
+> **开发者说明**：若您修改了源代码并希望构建本地测试镜像，请在 `docker-compose.yml` 中将 `dockerfile` 字段修改为 `docker/Dockerfile.source`。该 Dockerfile 会拷贝仓库源码并在镜像中编译 Go 服务端，同时仍通过 `mcp-proxy` 桥接器启动服务。
+
 ### 3.重启 Cursor 等进程，即可使用
 
 ## 可用工具

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+# 允许用户在 build 时传入指定的 NPM 版本号，默认为 latest
+ARG MCP_VERSION=latest
+
+# 安装指定版本的夜莺 MCP 发布包以及网络桥接器 mcp-proxy
+RUN npm config set registry https://registry.npmmirror.com && \
+    npm install -g @n9e/n9e-mcp-server@${MCP_VERSION} mcp-proxy
+
+EXPOSE 8082
+
+# 启动代理桥接器，并透传给全局安装的夜莺 MCP 二进制
+CMD ["mcp-proxy", "--port", "8082", "--", "n9e-mcp-server", "stdio"]

--- a/docker/Dockerfile.source
+++ b/docker/Dockerfile.source
@@ -1,0 +1,37 @@
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /src
+
+ARG GOPROXY=https://goproxy.cn,direct
+ARG GOSUMDB=sum.golang.org
+
+ENV CGO_ENABLED=0 \
+    GOPROXY=${GOPROXY} \
+    GOSUMDB=${GOSUMDB}
+
+# 优先拷贝依赖文件，利用 Docker 缓存
+COPY go.mod go.sum ./
+RUN go mod download
+
+# 拷贝 Go 源码并编译服务端
+COPY cmd ./cmd
+COPY internal ./internal
+COPY pkg ./pkg
+RUN go build -trimpath -ldflags="-s -w" -o /out/n9e-mcp-server ./cmd/n9e-mcp-server
+
+FROM node:22-alpine
+
+WORKDIR /app
+
+# 安装网络桥接器 mcp-proxy
+RUN npm config set registry https://registry.npmmirror.com && \
+    npm install -g mcp-proxy
+
+# 从构建阶段拷贝 Go 可执行文件
+COPY --from=builder /out/n9e-mcp-server /app/n9e-mcp-server
+RUN chmod +x /app/n9e-mcp-server
+
+EXPOSE 8082
+
+# 启动代理桥接器，并执行本地编译后的 Go 服务
+CMD ["mcp-proxy", "--port", "8082", "--", "/app/n9e-mcp-server", "stdio"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  n9e-mcp-server:
+    build:
+      context: .. # 使用仓库根目录作为构建上下文，支持源码编译模式
+      dockerfile: docker/Dockerfile # 默认使用 NPM 安装模式
+      # dockerfile: docker/Dockerfile.source # 开发者可取消注释，使用源码编译模式
+      args:
+        # 指定 NPM 包版本号，如 "0.1.1"；如需最新版请填写 latest
+        MCP_VERSION: "latest"
+    container_name: n9e-mcp-server
+    restart: always
+    environment:
+      # 夜莺 API 地址 (必须配置)
+      N9E_BASE_URL: "http://your-n9e-server:17000"
+      # 夜莺 API Token (必须配置)
+      N9E_TOKEN: "your_n9e_api_token_here"
+      # 可选：通过环境变量控制启用的工具集
+      # N9E_TOOLSETS: "alerts,targets,mutes"
+    ports:
+      - "8082:8082"
+    # 增加资源限制，保障宿主机稳定性
+    cpus: '0.5'
+    mem_limit: 512M


### PR DESCRIPTION
## Summary

This PR adds Docker-based deployment support for the n9e MCP server.

## Changes

- Add Dockerfiles for NPM package and local Go source builds
- Bridge the stdio MCP server to HTTP/SSE using mcp-proxy
- Add Docker Compose configuration for deployment
- Add Docker usage documentation in English and Chinese READMEs
- Normalize line endings for cross-platform development

## Notes

The Docker Compose setup is intended to simplify local deployment and integration with tools that require HTTP/SSE access.