### PR TITLE
feat: expand toolsets with CRUD/query/RBAC coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,35 +154,84 @@ The official code uses the `stdio` protocol by default for inter-process communi
 
 ## Available Tools
 
-| Toolset | Tool | Description |
-|---------|------|-------------|
-| alerts | `list_active_alerts` | List currently firing alerts with optional filters |
-| alerts | `get_active_alert` | Get details of a specific active alert by event ID |
-| alerts | `list_history_alerts` | List historical alerts with optional filters |
-| alerts | `get_history_alert` | Get details of a specific historical alert |
-| alerts | `list_alert_rules` | List alert rules for a business group |
-| alerts | `get_alert_rule` | Get details of a specific alert rule |
-| targets | `list_targets` | List monitored hosts/targets with optional filters |
-| datasource | `list_datasources` | List all available datasources |
-| mutes | `list_mutes` | List alert mutes for a business group |
-| mutes | `get_mute` | Get details of a specific alert mute |
-| mutes | `create_mute` | Create a new alert mute/silence rule |
-| mutes | `update_mute` | Update an existing alert mute/silence rule |
-| notify_rules | `list_notify_rules` | List all notification rules |
-| notify_rules | `get_notify_rule` | Get details of a specific notification rule |
-| alert_subscribes | `list_alert_subscribes` | List alert subscriptions for a business group |
-| alert_subscribes | `list_alert_subscribes_by_gids` | List subscriptions across multiple business groups |
-| alert_subscribes | `get_alert_subscribe` | Get details of a specific subscription |
-| event_pipelines | `list_event_pipelines` | List all event pipelines/workflows |
-| event_pipelines | `get_event_pipeline` | Get details of a specific event pipeline |
-| event_pipelines | `list_event_pipeline_executions` | List execution records for a specific pipeline |
-| event_pipelines | `list_all_event_pipeline_executions` | List all execution records across all pipelines |
-| event_pipelines | `get_event_pipeline_execution` | Get details of a specific execution |
-| users | `list_users` | List users with optional filters |
-| users | `get_user` | Get details of a specific user |
-| users | `list_user_groups` | List user groups/teams |
-| users | `get_user_group` | Get details of a user group including members |
-| busi_groups | `list_busi_groups` | List business groups accessible to the current user |
+Tools split into two tiers:
+
+- **read** — always available
+- **write** — registered unless `--read-only` is set (covers create/update/import/clone/toggle)
+
+The full default toolset list is `alerts, targets, datasource, mutes, busi_groups, notify_rules, alert_subscribes, event_pipelines, users, metrics, logs, dashboards, roles`. Restrict via `N9E_TOOLSETS`.
+
+### `alerts`
+
+| Tool | Tier | Description |
+|---|---|---|
+| `list_active_alerts` / `get_active_alert` | read | Active firing alerts |
+| `list_history_alerts` / `get_history_alert` | read | Historical alerts |
+| `list_alert_rules` / `get_alert_rule` | read | Alert rule listing |
+| `create_alert_rule` / `update_alert_rule` | write | CRUD on a single rule |
+| `import_alert_rules` / `import_prom_rules` | write | Bulk import (n9e JSON or Prometheus YAML) |
+| `clone_alert_rules_to_bgs` | write | Copy rules into target business groups |
+| `toggle_alert_rules` | write | Enable/disable a batch (uses `PUT .../fields`) |
+
+### `dashboards`
+
+| Tool | Tier | Description |
+|---|---|---|
+| `list_dashboards` / `get_dashboard` / `get_dashboard_pure` | read | List + metadata + full panel JSON |
+| `create_dashboard` / `update_dashboard_meta` / `update_dashboard_panels` | write | CRUD splits meta vs panels |
+| `set_dashboard_public` / `clone_dashboard` | write | Visibility + clone |
+
+### `notify_rules`
+
+| Tool | Tier | Description |
+|---|---|---|
+| `list_notify_rules` / `get_notify_rule` | read | Notification rules |
+| `list_notify_channels` / `get_notify_channel` / `list_notify_templates` | read | Channel + template listing |
+| `create_notify_rules` / `update_notify_rule` / `test_notify_rule` | write | Rule CRUD + dry-run test |
+| `create_notify_channel` / `update_notify_channel` | write | Channel CRUD |
+| `create_notify_template` / `update_notify_template` / `update_notify_template_content` | write | Template CRUD |
+
+### `datasource`
+
+| Tool | Tier | Description |
+|---|---|---|
+| `list_datasources` / `list_datasources_full` / `get_datasource` / `list_datasource_plugins` | read | Brief + full configs + supported plugins |
+| `upsert_datasource` | write | Create or update; n9e validates connectivity inside upsert |
+| `set_datasource_status` | write | Enable/disable batch |
+
+### `users`
+
+| Tool | Tier | Description |
+|---|---|---|
+| `list_users` / `get_user` / `list_user_groups` / `get_user_group` | read | |
+| `create_user` / `update_user_profile` / `reset_user_password` | write | Profile.roles assigns RBAC roles (no separate endpoint) |
+| `create_user_group` / `update_user_group` / `add_user_group_members` | write | Team management |
+
+### `roles` (RBAC)
+
+| Tool | Tier | Description |
+|---|---|---|
+| `list_roles` / `list_operations` / `list_role_operations` | read | |
+| `create_role` / `update_role` / `bind_role_operations` | write | `bind_role_operations` replaces (not deltas) |
+
+### `metrics` (Prometheus query proxy)
+
+| Tool | Tier | Description |
+|---|---|---|
+| `query_instant` | read | `/api/v1/query` via `/api/n9e/proxy/{ds_id}/...` |
+| `query_range` | read | Auto-adjusts `step` so result ≤ `max_points` (default 1000); flags `truncated:true` when downsampled |
+| `query_label_values` / `query_series` | read | |
+
+### `logs`
+
+| Tool | Tier | Description |
+|---|---|---|
+| `query_logs` | read | Plugin-dispatched `/logs-query` (Loki/ES/OS); default `limit=200`; rejects time ranges > 7 days |
+| `list_log_indices` / `list_log_fields` | read | ES (default) or OpenSearch (`engine=os`) |
+
+### `mutes` / `alert_subscribes` / `event_pipelines` / `targets` / `busi_groups`
+
+These keep their existing tools (see prior versions). `mutes` adds no new tools in this revision.
 
 ## Example Prompts
 
@@ -209,7 +258,7 @@ Once configured, you can interact with Nightingale using natural language:
 |----------|------|-------------|---------|
 | `N9E_TOKEN` | `--token` | Nightingale API token (required) | - |
 | `N9E_BASE_URL` | `--base-url` | Nightingale API base URL | `http://localhost:17000` |
-| `N9E_READ_ONLY` | `--read-only` | Disable write operations | `false` |
+| `N9E_READ_ONLY` | `--read-only` | Disable write operations (only `read` tools registered) | `false` |
 | `N9E_TOOLSETS` | `--toolsets` | Enabled toolsets (comma-separated) | `all` |
 | `N9E_LISTEN` | `--listen` | HTTP mode: listen address | `:8080` |
 | `N9E_SESSION_TIMEOUT` | `--session-timeout` | HTTP mode: idle session timeout (0 = no timeout) | `0` |
@@ -218,7 +267,7 @@ Once configured, you can interact with Nightingale using natural language:
 
 By default, all toolsets are enabled. You can use the `--toolsets` flag or `N9E_TOOLSETS` environment variable to enable only the toolsets you need, reducing the number of tools exposed to the AI assistant and saving context window tokens.
 
-Available toolsets: `alerts`, `targets`, `datasource`, `mutes`, `busi_groups`, `notify_rules`, `alert_subscribes`, `event_pipelines`, `users`
+Available toolsets: `alerts`, `targets`, `datasource`, `mutes`, `busi_groups`, `notify_rules`, `alert_subscribes`, `event_pipelines`, `users`, `metrics`, `logs`, `dashboards`, `roles`
 
 For example, to enable only alert and target related tools:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -153,35 +153,78 @@ N9E_TOKEN=xxx N9E_BASE_URL=https://n9e.example.com n9e-mcp-server http --listen 
 
 ## 可用工具
 
-| 工具集 | 工具 | 说明 |
-|-------|------|------|
-| alerts | `list_active_alerts` | 列出当前活跃告警，支持过滤条件 |
-| alerts | `get_active_alert` | 根据事件 ID 获取活跃告警详情 |
-| alerts | `list_history_alerts` | 列出历史告警，支持过滤条件 |
-| alerts | `get_history_alert` | 获取历史告警详情 |
-| alerts | `list_alert_rules` | 列出业务组的告警规则 |
-| alerts | `get_alert_rule` | 获取告警规则详情 |
-| targets | `list_targets` | 列出被监控主机/目标，支持过滤条件 |
-| datasource | `list_datasources` | 列出所有可用数据源 |
-| mutes | `list_mutes` | 列出业务组的告警屏蔽规则 |
-| mutes | `get_mute` | 获取告警屏蔽规则详情 |
-| mutes | `create_mute` | 创建告警屏蔽规则 |
-| mutes | `update_mute` | 更新告警屏蔽规则 |
-| notify_rules | `list_notify_rules` | 列出所有通知规则 |
-| notify_rules | `get_notify_rule` | 获取通知规则详情 |
-| alert_subscribes | `list_alert_subscribes` | 列出业务组的告警订阅 |
-| alert_subscribes | `list_alert_subscribes_by_gids` | 列出多个业务组的订阅 |
-| alert_subscribes | `get_alert_subscribe` | 获取订阅详情 |
-| event_pipelines | `list_event_pipelines` | 列出所有事件流水线 |
-| event_pipelines | `get_event_pipeline` | 获取事件流水线详情 |
-| event_pipelines | `list_event_pipeline_executions` | 列出指定流水线的执行记录 |
-| event_pipelines | `list_all_event_pipeline_executions` | 列出所有流水线的执行记录 |
-| event_pipelines | `get_event_pipeline_execution` | 获取执行记录详情 |
-| users | `list_users` | 列出用户，支持过滤条件 |
-| users | `get_user` | 获取用户详情 |
-| users | `list_user_groups` | 列出用户组/团队 |
-| users | `get_user_group` | 获取用户组详情（包含成员） |
-| busi_groups | `list_busi_groups` | 列出当前用户可访问的业务组 |
+工具按两档安全等级组织:
+
+- **read** — 始终注册
+- **write** — `--read-only` 关闭时注册(create/update/import/clone/toggle 等)
+
+完整 toolset 列表: `alerts、targets、datasource、mutes、busi_groups、notify_rules、alert_subscribes、event_pipelines、users、metrics、logs、dashboards、roles`,可通过 `N9E_TOOLSETS` 缩减。
+
+下面只列出新增/扩展的部分;原有工具(targets、busi_groups、event_pipelines、alert_subscribes、mutes)保持不变。
+
+### `alerts`(扩展)
+
+| 工具 | 等级 | 说明 |
+|---|---|---|
+| `list_active_alerts` / `get_active_alert` / `list_history_alerts` / `get_history_alert` / `list_alert_rules` / `get_alert_rule` | read | 已有读工具 |
+| `create_alert_rule` / `update_alert_rule` | write | 单条 CRUD |
+| `import_alert_rules` / `import_prom_rules` | write | 批量导入(n9e JSON 或 Prometheus YAML) |
+| `clone_alert_rules_to_bgs` / `toggle_alert_rules` | write | 跨业务组克隆 / 批量启停(走 `PUT .../fields`) |
+
+### `dashboards`(新)
+
+| 工具 | 等级 | 说明 |
+|---|---|---|
+| `list_dashboards` / `get_dashboard` / `get_dashboard_pure` | read | 列表 + 元数据 + 完整面板 JSON |
+| `create_dashboard` / `update_dashboard_meta` / `update_dashboard_panels` | write | 元数据与面板分开更新 |
+| `set_dashboard_public` / `clone_dashboard` | write | 可见性切换 + 克隆 |
+
+### `notify_rules`(扩展,含 channels + templates)
+
+| 工具 | 等级 | 说明 |
+|---|---|---|
+| `list_notify_rules` / `get_notify_rule` / `list_notify_channels` / `get_notify_channel` / `list_notify_templates` | read | |
+| `create_notify_rules` / `update_notify_rule` / `test_notify_rule` | write | 规则 CRUD + 干跑测试 |
+| `create_notify_channel` / `update_notify_channel` | write | 通道 CRUD |
+| `create_notify_template` / `update_notify_template` / `update_notify_template_content` | write | 模板 CRUD |
+
+### `datasource`(扩展)
+
+| 工具 | 等级 | 说明 |
+|---|---|---|
+| `list_datasources` / `list_datasources_full` / `get_datasource` / `list_datasource_plugins` | read | brief / 完整 / 插件类型 |
+| `upsert_datasource` | write | 创建或更新一体化(n9e 在 upsert 内部做连通性校验,无独立 test 端点) |
+| `set_datasource_status` | write | 批量启停 |
+
+### `users`(扩展)
+
+| 工具 | 等级 | 说明 |
+|---|---|---|
+| `list_users` / `get_user` / `list_user_groups` / `get_user_group` | read | |
+| `create_user` / `update_user_profile` / `reset_user_password` | write | profile.roles 字段即角色分配(n9e 没有独立分配端点) |
+| `create_user_group` / `update_user_group` / `add_user_group_members` | write | 团队管理 |
+
+### `roles`(新)
+
+| 工具 | 等级 | 说明 |
+|---|---|---|
+| `list_roles` / `list_operations` / `list_role_operations` | read | |
+| `create_role` / `update_role` / `bind_role_operations` | write | bind 是替换语义,不是增量 |
+
+### `metrics`(新,Prom 查询代理)
+
+| 工具 | 等级 | 说明 |
+|---|---|---|
+| `query_instant` | read | `/api/v1/query` |
+| `query_range` | read | 自动调整 `step` 让结果点数 ≤ `max_points`(默认 1000),被降采样时返回 `truncated:true` |
+| `query_label_values` / `query_series` | read | |
+
+### `logs`(新)
+
+| 工具 | 等级 | 说明 |
+|---|---|---|
+| `query_logs` | read | n9e 插件分发的 `/logs-query`(Loki/ES/OS 通吃);默认 `limit=200`;时间跨度 > 7 天直接拒绝 |
+| `list_log_indices` / `list_log_fields` | read | ES(默认)或 OpenSearch(`engine=os`) |
 
 ## 示例提示词
 
@@ -208,7 +251,7 @@ N9E_TOKEN=xxx N9E_BASE_URL=https://n9e.example.com n9e-mcp-server http --listen 
 |-----|-----------|------|-------|
 | `N9E_TOKEN` | `--token` | 夜莺 API Token（必需） | - |
 | `N9E_BASE_URL` | `--base-url` | 夜莺 API 地址 | `http://localhost:17000` |
-| `N9E_READ_ONLY` | `--read-only` | 禁用写操作 | `false` |
+| `N9E_READ_ONLY` | `--read-only` | 仅注册 read 工具,屏蔽全部 write 工具 | `false` |
 | `N9E_TOOLSETS` | `--toolsets` | 启用的工具集（逗号分隔） | `all` |
 | `N9E_LISTEN` | `--listen` | HTTP 模式：监听地址 | `:8080` |
 | `N9E_SESSION_TIMEOUT` | `--session-timeout` | HTTP 模式：空闲会话超时（0 表示不超时） | `0` |
@@ -218,7 +261,7 @@ N9E_TOKEN=xxx N9E_BASE_URL=https://n9e.example.com n9e-mcp-server http --listen 
 
 默认启用所有工具集。可以通过 `--toolsets` 参数或 `N9E_TOOLSETS` 环境变量只启用需要的工具集，减少暴露给 AI 助手的工具数量，节省上下文窗口的 token 消耗。
 
-可用工具集：`alerts`、`targets`、`datasource`、`mutes`、`busi_groups`、`notify_rules`、`alert_subscribes`、`event_pipelines`、`users`
+可用工具集：`alerts`、`targets`、`datasource`、`mutes`、`busi_groups`、`notify_rules`、`alert_subscribes`、`event_pipelines`、`users`、`metrics`、`logs`、`dashboards`、`roles`
 
 例如，只启用告警和监控目标相关工具：
 

--- a/pkg/api/alerts.go
+++ b/pkg/api/alerts.go
@@ -79,6 +79,16 @@ func RegisterAlertsToolset(group *toolset.ToolsetGroup, getClient client.GetClie
 		getAlertRuleTool(getClient),
 	)
 
+	// Write tools (create/update/import/clone/toggle)
+	ts.AddWriteTools(
+		createAlertRuleTool(getClient),
+		updateAlertRuleTool(getClient),
+		importAlertRulesTool(getClient),
+		importPromRulesTool(getClient),
+		cloneAlertRulesToBgsTool(getClient),
+		toggleAlertRulesTool(getClient),
+	)
+
 	group.AddToolset(ts)
 }
 
@@ -504,6 +514,338 @@ func getAlertRuleTool(getClient client.GetClientFunc) toolset.ServerTool {
 			}
 
 			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+// --- Write tools ---
+
+// CreateAlertRuleInput accepts a full rule object (matches the shape returned by get_alert_rule).
+// Using map[string]any keeps the surface flexible across n9e versions and rule categories
+// (metric/log/host/anomaly each carry different `rule_config`/`severities` shapes).
+type CreateAlertRuleInput struct {
+	GroupId int64          `json:"group_id"`
+	Rule    map[string]any `json:"rule"`
+}
+
+func createAlertRuleTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "create_alert_rule",
+			Description: "Create a new alert rule in a business group. Pass the full rule body in 'rule' (mirror the structure returned by get_alert_rule, omit id/create_at/update_at).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create Alert Rule",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"group_id", "rule"},
+				Properties: map[string]*jsonschema.Schema{
+					"group_id": {Type: "integer", Description: "Business group ID"},
+					"rule": {
+						Type:        "object",
+						Description: "Full alert rule body. Must include name, prod, cate, severity, and rule_config / prom_ql appropriate for the rule kind.",
+					},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input CreateAlertRuleInput) (*mcp.CallToolResult, error) {
+			if input.GroupId <= 0 {
+				return toolset.NewToolResultError("group_id is required and must be positive"), nil
+			}
+			if len(input.Rule) == 0 {
+				return toolset.NewToolResultError("rule body is required"), nil
+			}
+
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			path := fmt.Sprintf("/api/n9e/busi-group/%d/alert-rules", input.GroupId)
+			result, err := client.DoPost[any](c, ctx, path, []map[string]any{input.Rule})
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{
+				"result":  result,
+				"message": "Alert rule created",
+			}), nil
+		}),
+	)
+}
+
+// UpdateAlertRuleInput updates a single rule by id within its business group.
+type UpdateAlertRuleInput struct {
+	GroupId int64          `json:"group_id"`
+	RuleId  int64          `json:"arid"`
+	Rule    map[string]any `json:"rule"`
+}
+
+func updateAlertRuleTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_alert_rule",
+			Description: "Update an existing alert rule. Pass the full rule body (typically: get_alert_rule, modify fields, then submit).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Alert Rule",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"group_id", "arid", "rule"},
+				Properties: map[string]*jsonschema.Schema{
+					"group_id": {Type: "integer", Description: "Business group ID owning the rule"},
+					"arid":     {Type: "integer", Description: "Alert rule ID"},
+					"rule":     {Type: "object", Description: "Full rule body"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input UpdateAlertRuleInput) (*mcp.CallToolResult, error) {
+			if input.GroupId <= 0 || input.RuleId <= 0 {
+				return toolset.NewToolResultError("group_id and arid are required and must be positive"), nil
+			}
+			if len(input.Rule) == 0 {
+				return toolset.NewToolResultError("rule body is required"), nil
+			}
+
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			path := fmt.Sprintf("/api/n9e/busi-group/%d/alert-rule/%d", input.GroupId, input.RuleId)
+			_, err := client.DoPut[any](c, ctx, path, input.Rule)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{
+				"id":      input.RuleId,
+				"message": "Alert rule updated",
+			}), nil
+		}),
+	)
+}
+
+// ImportAlertRulesInput bulk-imports an array of rule bodies.
+type ImportAlertRulesInput struct {
+	GroupId int64            `json:"group_id"`
+	Rules   []map[string]any `json:"rules"`
+}
+
+func importAlertRulesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "import_alert_rules",
+			Description: "Bulk import alert rules into a business group from a JSON array (matches the n9e import format).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Import Alert Rules",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"group_id", "rules"},
+				Properties: map[string]*jsonschema.Schema{
+					"group_id": {Type: "integer", Description: "Business group ID"},
+					"rules": {
+						Type:        "array",
+						Description: "Array of rule bodies",
+						Items:       &jsonschema.Schema{Type: "object"},
+					},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input ImportAlertRulesInput) (*mcp.CallToolResult, error) {
+			if input.GroupId <= 0 {
+				return toolset.NewToolResultError("group_id is required and must be positive"), nil
+			}
+			if len(input.Rules) == 0 {
+				return toolset.NewToolResultError("rules must be a non-empty array"), nil
+			}
+
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			path := fmt.Sprintf("/api/n9e/busi-group/%d/alert-rules/import", input.GroupId)
+			result, err := client.DoPost[any](c, ctx, path, input.Rules)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{
+				"result":   result,
+				"imported": len(input.Rules),
+			}), nil
+		}),
+	)
+}
+
+// ImportPromRulesInput imports Prometheus YAML/JSON rule definitions.
+type ImportPromRulesInput struct {
+	GroupId           int64  `json:"group_id"`
+	Payload           string `json:"payload"`
+	DatasourceQueries any    `json:"datasource_queries,omitempty"`
+	Disabled          int    `json:"disabled,omitempty"`
+}
+
+func importPromRulesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "import_prom_rules",
+			Description: "Import Prometheus alerting rules (YAML or JSON) into a business group. Wraps n9e's /alert-rules/import-prom-rule endpoint.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Import Prometheus Rules",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"group_id", "payload"},
+				Properties: map[string]*jsonschema.Schema{
+					"group_id":           {Type: "integer", Description: "Business group ID"},
+					"payload":            {Type: "string", Description: "Raw Prometheus rules YAML/JSON"},
+					"datasource_queries": {Description: "Datasource selector (matches the FE wizard payload)"},
+					"disabled":           {Type: "integer", Description: "Create rules disabled (0 = enabled, 1 = disabled)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input ImportPromRulesInput) (*mcp.CallToolResult, error) {
+			if input.GroupId <= 0 {
+				return toolset.NewToolResultError("group_id is required and must be positive"), nil
+			}
+			if input.Payload == "" {
+				return toolset.NewToolResultError("payload is required"), nil
+			}
+
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			body := map[string]any{
+				"Payload":           input.Payload,
+				"DatasourceQueries": input.DatasourceQueries,
+				"Disabled":          input.Disabled,
+			}
+			path := fmt.Sprintf("/api/n9e/busi-group/%d/alert-rules/import-prom-rule", input.GroupId)
+			result, err := client.DoPost[any](c, ctx, path, body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result}), nil
+		}),
+	)
+}
+
+// CloneAlertRulesToBgsInput clones rules to one or more target business groups.
+type CloneAlertRulesToBgsInput struct {
+	RuleIds []int64 `json:"rule_ids"`
+	Bgids   []int64 `json:"bgids"`
+}
+
+func cloneAlertRulesToBgsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "clone_alert_rules_to_bgs",
+			Description: "Clone the given alert rules into one or more target business groups.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Clone Alert Rules to Business Groups",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"rule_ids", "bgids"},
+				Properties: map[string]*jsonschema.Schema{
+					"rule_ids": {Type: "array", Description: "Source rule IDs", Items: &jsonschema.Schema{Type: "integer"}},
+					"bgids":    {Type: "array", Description: "Target business group IDs", Items: &jsonschema.Schema{Type: "integer"}},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input CloneAlertRulesToBgsInput) (*mcp.CallToolResult, error) {
+			if len(input.RuleIds) == 0 || len(input.Bgids) == 0 {
+				return toolset.NewToolResultError("rule_ids and bgids are required and must be non-empty"), nil
+			}
+
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			body := map[string]any{
+				"RuleIds": input.RuleIds,
+				"Bgids":   input.Bgids,
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/busi-groups/alert-rules/clones", body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result}), nil
+		}),
+	)
+}
+
+// ToggleAlertRulesInput enables or disables a batch of rules within a business group.
+type ToggleAlertRulesInput struct {
+	GroupId  int64   `json:"group_id"`
+	Ids      []int64 `json:"ids"`
+	Disabled int     `json:"disabled"`
+}
+
+func toggleAlertRulesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "toggle_alert_rules",
+			Description: "Enable or disable a batch of alert rules. Uses n9e's PUT .../alert-rules/fields with {disabled:0|1}.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Toggle Alert Rules",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"group_id", "ids", "disabled"},
+				Properties: map[string]*jsonschema.Schema{
+					"group_id": {Type: "integer", Description: "Business group ID"},
+					"ids":      {Type: "array", Description: "Alert rule IDs", Items: &jsonschema.Schema{Type: "integer"}},
+					"disabled": {Type: "integer", Description: "0 = enable, 1 = disable"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input ToggleAlertRulesInput) (*mcp.CallToolResult, error) {
+			if input.GroupId <= 0 {
+				return toolset.NewToolResultError("group_id is required and must be positive"), nil
+			}
+			if len(input.Ids) == 0 {
+				return toolset.NewToolResultError("ids must be non-empty"), nil
+			}
+			if input.Disabled != 0 && input.Disabled != 1 {
+				return toolset.NewToolResultError("disabled must be 0 or 1"), nil
+			}
+
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			body := map[string]any{
+				"ids":    input.Ids,
+				"fields": map[string]any{"disabled": input.Disabled},
+				"action": "update_fields",
+			}
+			path := fmt.Sprintf("/api/n9e/busi-group/%d/alert-rules/fields", input.GroupId)
+			_, err := client.DoPut[any](c, ctx, path, body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{
+				"updated":  len(input.Ids),
+				"disabled": input.Disabled,
+			}), nil
 		}),
 	)
 }

--- a/pkg/api/dashboards.go
+++ b/pkg/api/dashboards.go
@@ -1,0 +1,387 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/n9e/n9e-mcp-server/pkg/client"
+	"github.com/n9e/n9e-mcp-server/pkg/toolset"
+	"github.com/n9e/n9e-mcp-server/pkg/types"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// dashboardMaxResponseSize allows board configs to exceed the default 10MB cap
+// when fetching panel JSON via /board/{bid}/pure.
+const dashboardMaxResponseSize = 64 * 1024 * 1024
+
+// RegisterDashboardsToolset registers the dashboards (boards) toolset.
+func RegisterDashboardsToolset(group *toolset.ToolsetGroup, getClient client.GetClientFunc) {
+	ts := toolset.NewToolset("dashboards", "Dashboard (board) management: list/get/create/update/clone")
+
+	ts.AddReadTools(
+		listDashboardsTool(getClient),
+		getDashboardTool(getClient),
+		getDashboardPureTool(getClient),
+	)
+
+	ts.AddWriteTools(
+		createDashboardTool(getClient),
+		updateDashboardMetaTool(getClient),
+		updateDashboardPanelsTool(getClient),
+		setDashboardPublicTool(getClient),
+		cloneDashboardTool(getClient),
+	)
+
+	group.AddToolset(ts)
+}
+
+// --- Read ---
+
+type listDashboardsInput struct {
+	GroupId int64  `json:"group_id,omitempty"`
+	Gids    string `json:"gids,omitempty"`
+	Query   string `json:"query,omitempty"`
+}
+
+func listDashboardsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_dashboards",
+			Description: "List dashboards. Pass group_id for a single business group, or gids (comma-separated) to query multiple.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Dashboards",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"group_id": {Type: "integer", Description: "Business group ID (single)"},
+					"gids":     {Type: "string", Description: "Comma-separated business group IDs (multi)"},
+					"query":    {Type: "string", Description: "Optional name search"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input listDashboardsInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			params := url.Values{}
+			if input.Query != "" {
+				params.Set("query", input.Query)
+			}
+
+			if input.GroupId > 0 {
+				path := fmt.Sprintf("/api/n9e/busi-group/%d/boards", input.GroupId)
+				result, err := client.DoGet[any](c, ctx, path, params)
+				if err != nil {
+					return toolset.NewToolResultError(err.Error()), nil
+				}
+				return toolset.MarshalResult(result), nil
+			}
+
+			if input.Gids != "" {
+				params.Set("gids", input.Gids)
+			}
+			result, err := client.DoGet[any](c, ctx, "/api/n9e/busi-groups/boards", params)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+type getDashboardInput struct {
+	Bid int64 `json:"bid"`
+}
+
+func getDashboardTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "get_dashboard",
+			Description: "Get a dashboard's metadata by ID. Use get_dashboard_pure if you also need the panel configs.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Dashboard",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"bid"},
+				Properties: map[string]*jsonschema.Schema{
+					"bid": {Type: "integer", Description: "Board ID"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input getDashboardInput) (*mcp.CallToolResult, error) {
+			if input.Bid <= 0 {
+				return toolset.NewToolResultError("bid is required and must be positive"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoGet[types.Board](c, ctx, fmt.Sprintf("/api/n9e/board/%d", input.Bid), nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+func getDashboardPureTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "get_dashboard_pure",
+			Description: "Get a dashboard including its full panel JSON. Uses an extended response size cap (64MB) — large boards return their entire layout.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Dashboard (Full Panels)",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"bid"},
+				Properties: map[string]*jsonschema.Schema{
+					"bid": {Type: "integer", Description: "Board ID"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input getDashboardInput) (*mcp.CallToolResult, error) {
+			if input.Bid <= 0 {
+				return toolset.NewToolResultError("bid is required and must be positive"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoGetLarge[types.Board](c, ctx, fmt.Sprintf("/api/n9e/board/%d/pure", input.Bid), nil, dashboardMaxResponseSize)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+// --- Write ---
+
+type createDashboardInput struct {
+	GroupId int64          `json:"group_id"`
+	Board   map[string]any `json:"board"`
+}
+
+func createDashboardTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "create_dashboard",
+			Description: "Create a new dashboard inside a business group.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create Dashboard",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"group_id", "board"},
+				Properties: map[string]*jsonschema.Schema{
+					"group_id": {Type: "integer"},
+					"board":    {Type: "object", Description: "Board body (name, ident, tags, configs, ...)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input createDashboardInput) (*mcp.CallToolResult, error) {
+			if input.GroupId <= 0 {
+				return toolset.NewToolResultError("group_id is required and must be positive"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			path := fmt.Sprintf("/api/n9e/busi-group/%d/boards", input.GroupId)
+			result, err := client.DoPost[any](c, ctx, path, input.Board)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result, "message": "Dashboard created"}), nil
+		}),
+	)
+}
+
+type updateDashboardMetaInput struct {
+	Bid   int64          `json:"bid"`
+	Patch map[string]any `json:"patch"`
+}
+
+func updateDashboardMetaTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_dashboard_meta",
+			Description: "Update a dashboard's name and tags (PUT /board/{bid}). Use update_dashboard_panels to change the panel JSON.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Dashboard Meta",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"bid", "patch"},
+				Properties: map[string]*jsonschema.Schema{
+					"bid":   {Type: "integer"},
+					"patch": {Type: "object", Description: "Fields to update (name, tags, ident)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateDashboardMetaInput) (*mcp.CallToolResult, error) {
+			if input.Bid <= 0 {
+				return toolset.NewToolResultError("bid is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/board/%d", input.Bid), input.Patch)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Bid, "message": "Dashboard meta updated"}), nil
+		}),
+	)
+}
+
+type updateDashboardPanelsInput struct {
+	Bid     int64  `json:"bid"`
+	Configs string `json:"configs"`
+}
+
+func updateDashboardPanelsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_dashboard_panels",
+			Description: "Replace a dashboard's panel JSON (PUT /board/{bid}/configs). 'configs' must be a JSON string.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Dashboard Panels",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"bid", "configs"},
+				Properties: map[string]*jsonschema.Schema{
+					"bid":     {Type: "integer"},
+					"configs": {Type: "string", Description: "Panel JSON as a string (n9e stores it as text)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateDashboardPanelsInput) (*mcp.CallToolResult, error) {
+			if input.Bid <= 0 {
+				return toolset.NewToolResultError("bid is required"), nil
+			}
+			if input.Configs == "" {
+				return toolset.NewToolResultError("configs is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/board/%d/configs", input.Bid), map[string]any{"configs": input.Configs})
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Bid, "message": "Dashboard panels updated"}), nil
+		}),
+	)
+}
+
+type setDashboardPublicInput struct {
+	Bid        int64 `json:"bid"`
+	Public     int   `json:"public"`
+	PublicCate int   `json:"public_cate,omitempty"`
+}
+
+func setDashboardPublicTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "set_dashboard_public",
+			Description: "Toggle a dashboard's public visibility (PUT /board/{bid}/public).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Set Dashboard Public",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"bid", "public"},
+				Properties: map[string]*jsonschema.Schema{
+					"bid":         {Type: "integer"},
+					"public":      {Type: "integer", Description: "0 = private, 1 = public"},
+					"public_cate": {Type: "integer", Description: "Visibility category (n9e enum)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input setDashboardPublicInput) (*mcp.CallToolResult, error) {
+			if input.Bid <= 0 {
+				return toolset.NewToolResultError("bid is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			body := map[string]any{"public": input.Public}
+			if input.PublicCate != 0 {
+				body["public_cate"] = input.PublicCate
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/board/%d/public", input.Bid), body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Bid, "public": input.Public}), nil
+		}),
+	)
+}
+
+type cloneDashboardInput struct {
+	GroupId int64 `json:"group_id"`
+	Bid     int64 `json:"bid"`
+}
+
+func cloneDashboardTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "clone_dashboard",
+			Description: "Clone a dashboard into the same business group (POST /busi-group/{gid}/board/{bid}/clone).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Clone Dashboard",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"group_id", "bid"},
+				Properties: map[string]*jsonschema.Schema{
+					"group_id": {Type: "integer"},
+					"bid":      {Type: "integer"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input cloneDashboardInput) (*mcp.CallToolResult, error) {
+			if input.GroupId <= 0 || input.Bid <= 0 {
+				return toolset.NewToolResultError("group_id and bid are required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			path := fmt.Sprintf("/api/n9e/busi-group/%d/board/%d/clone", input.GroupId, input.Bid)
+			result, err := client.DoPost[any](c, ctx, path, nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result}), nil
+		}),
+	)
+}

--- a/pkg/api/datasource.go
+++ b/pkg/api/datasource.go
@@ -17,12 +17,24 @@ type ListDatasourcesInput struct {
 	Page  int `json:"p,omitempty"`
 }
 
-// RegisterDatasourceToolset registers datasource toolset
+// RegisterDatasourceToolset registers datasource toolset.
+//
+// Note: n9e's datasource API is unusual — endpoints are POST even for reads,
+// and create/update share /datasource/upsert (which also runs the connectivity
+// check). There is no separate test-connection endpoint.
 func RegisterDatasourceToolset(group *toolset.ToolsetGroup, getClient client.GetClientFunc) {
-	ts := toolset.NewToolset("datasource", "Datasource management tools")
+	ts := toolset.NewToolset("datasource", "Datasource management tools (Prometheus/VictoriaMetrics/Loki/ES/...)")
 
 	ts.AddReadTools(
 		listDatasourcesTool(getClient),
+		listDatasourcesFullTool(getClient),
+		getDatasourceTool(getClient),
+		listDatasourcePluginsTool(getClient),
+	)
+
+	ts.AddWriteTools(
+		upsertDatasourceTool(getClient),
+		setDatasourceStatusTool(getClient),
 	)
 
 	group.AddToolset(ts)
@@ -32,7 +44,7 @@ func listDatasourcesTool(getClient client.GetClientFunc) toolset.ServerTool {
 	return toolset.NewServerTool(
 		mcp.Tool{
 			Name:        "list_datasources",
-			Description: "List all available datasources",
+			Description: "List all available datasources (sanitized brief view — no auth secrets)",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Datasources",
 				ReadOnlyHint: true,
@@ -40,14 +52,8 @@ func listDatasourcesTool(getClient client.GetClientFunc) toolset.ServerTool {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
-					"limit": {
-						Type:        "integer",
-						Description: "Page size (default 20)",
-					},
-					"p": {
-						Type:        "integer",
-						Description: "Page number (starts from 1)",
-					},
+					"limit": {Type: "integer", Description: "Page size (default 20)"},
+					"p":     {Type: "integer", Description: "Page number (starts from 1)"},
 				},
 			},
 		},
@@ -67,3 +73,189 @@ func listDatasourcesTool(getClient client.GetClientFunc) toolset.ServerTool {
 		}),
 	)
 }
+
+type listDatasourcesFullInput struct {
+	Body map[string]any `json:"body,omitempty"`
+}
+
+func listDatasourcesFullTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_datasources_full",
+			Description: "List datasources with full configuration including auth (admin perspective). Pass an optional filter body matching n9e's /datasource/list payload.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Datasources (Full)",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"body": {Type: "object", Description: "Optional filter body (e.g. plugin types, name search)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input listDatasourcesFullInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			body := input.Body
+			if body == nil {
+				body = map[string]any{}
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/datasource/list", body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+type getDatasourceInput struct {
+	Id int64 `json:"id"`
+}
+
+func getDatasourceTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "get_datasource",
+			Description: "Get full configuration of a single datasource by ID (POST /datasource/desc).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Datasource",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id"},
+				Properties: map[string]*jsonschema.Schema{
+					"id": {Type: "integer", Description: "Datasource ID"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input getDatasourceInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 {
+				return toolset.NewToolResultError("id is required and must be positive"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/datasource/desc", map[string]any{"id": input.Id})
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+func listDatasourcePluginsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_datasource_plugins",
+			Description: "List supported datasource plugin types (Prometheus, Loki, ES, Tencent CLS, ...).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Datasource Plugins",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{Type: "object"},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/datasource/plugin/list", map[string]any{})
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+type upsertDatasourceInput struct {
+	Datasource map[string]any `json:"datasource"`
+}
+
+func upsertDatasourceTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "upsert_datasource",
+			Description: "Create or update a datasource. n9e runs a connectivity check as part of upsert — a successful response implies the datasource is reachable. Omit 'id' to create.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Upsert Datasource",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"datasource"},
+				Properties: map[string]*jsonschema.Schema{
+					"datasource": {Type: "object", Description: "Datasource body (matches the shape returned by get_datasource)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input upsertDatasourceInput) (*mcp.CallToolResult, error) {
+			if len(input.Datasource) == 0 {
+				return toolset.NewToolResultError("datasource body is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/datasource/upsert", input.Datasource)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result}), nil
+		}),
+	)
+}
+
+type setDatasourceStatusInput struct {
+	Ids    []int64 `json:"ids"`
+	Status string  `json:"status"` // "enabled" or "disabled"
+}
+
+func setDatasourceStatusTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "set_datasource_status",
+			Description: "Enable or disable one or more datasources (POST /datasource/status/update).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Set Datasource Status",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"ids", "status"},
+				Properties: map[string]*jsonschema.Schema{
+					"ids":    {Type: "array", Items: &jsonschema.Schema{Type: "integer"}, Description: "Datasource IDs"},
+					"status": {Type: "string", Description: "'enabled' or 'disabled'"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input setDatasourceStatusInput) (*mcp.CallToolResult, error) {
+			if len(input.Ids) == 0 {
+				return toolset.NewToolResultError("ids must be non-empty"), nil
+			}
+			if input.Status != "enabled" && input.Status != "disabled" {
+				return toolset.NewToolResultError("status must be 'enabled' or 'disabled'"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			body := map[string]any{"ids": input.Ids, "status": input.Status}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/datasource/status/update", body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result}), nil
+		}),
+	)
+}
+

--- a/pkg/api/logs.go
+++ b/pkg/api/logs.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/n9e/n9e-mcp-server/pkg/client"
+	"github.com/n9e/n9e-mcp-server/pkg/toolset"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// defaultLogLimit caps the number of log lines returned per query.
+const defaultLogLimit = 200
+
+// maxLogRangeSeconds rejects log queries spanning more than 7 days to prevent runaway costs.
+const maxLogRangeSeconds = 7 * 24 * 60 * 60
+
+// RegisterLogsToolset registers the logs-query toolset.
+// Backed by n9e's plugin-dispatched /api/n9e/logs-query (Loki/ES/OS).
+func RegisterLogsToolset(group *toolset.ToolsetGroup, getClient client.GetClientFunc) {
+	ts := toolset.NewToolset("logs", "Logs query tools (Loki/Elasticsearch/OpenSearch) via n9e logs-query")
+
+	ts.AddReadTools(
+		queryLogsTool(getClient),
+		listLogIndicesTool(getClient),
+		listLogFieldsTool(getClient),
+	)
+
+	group.AddToolset(ts)
+}
+
+type queryLogsInput struct {
+	Body  map[string]any `json:"body"`
+	Limit int            `json:"limit,omitempty"`
+	Start int64          `json:"start,omitempty"`
+	End   int64          `json:"end,omitempty"`
+}
+
+func queryLogsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "query_logs",
+			Description: "Query logs from a datasource (Loki/ES/OS) via n9e's plugin-dispatched /logs-query endpoint. Pass 'body' as the n9e query payload (must include datasource_id and the engine-specific query). Time range > 7 days is rejected.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Query Logs",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"body"},
+				Properties: map[string]*jsonschema.Schema{
+					"body":  {Type: "object", Description: "Log query body (matches n9e's /logs-query payload)"},
+					"limit": {Type: "integer", Description: "Cap on returned lines (default 200)"},
+					"start": {Type: "integer", Description: "Optional Unix-second start (used only for range validation)"},
+					"end":   {Type: "integer", Description: "Optional Unix-second end (used only for range validation)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input queryLogsInput) (*mcp.CallToolResult, error) {
+			if len(input.Body) == 0 {
+				return toolset.NewToolResultError("body is required"), nil
+			}
+			if input.Start > 0 && input.End > 0 {
+				if input.End-input.Start > maxLogRangeSeconds {
+					return toolset.NewToolResultError(fmt.Sprintf("time range exceeds max of %d seconds (~7 days)", maxLogRangeSeconds)), nil
+				}
+			}
+
+			body := input.Body
+			limit := input.Limit
+			if limit <= 0 {
+				limit = defaultLogLimit
+			}
+			// Inject limit if the caller didn't set one (n9e plugins inspect this hint differently).
+			if _, ok := body["limit"]; !ok {
+				body["limit"] = limit
+			}
+
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/logs-query", body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{
+				"limit": limit,
+				"data":  result,
+			}), nil
+		}),
+	)
+}
+
+type logIndicesInput struct {
+	Body   map[string]any `json:"body"`
+	Engine string         `json:"engine,omitempty"` // "es" (default) or "os" (OpenSearch)
+}
+
+func listLogIndicesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_log_indices",
+			Description: "List indices for an Elasticsearch (default) or OpenSearch datasource. Body must include datasource_id.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Log Indices",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"body"},
+				Properties: map[string]*jsonschema.Schema{
+					"body":   {Type: "object", Description: "Body (must include datasource_id)"},
+					"engine": {Type: "string", Description: "'es' (default) or 'os' for OpenSearch"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input logIndicesInput) (*mcp.CallToolResult, error) {
+			if len(input.Body) == 0 {
+				return toolset.NewToolResultError("body is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			path := "/api/n9e/indices"
+			if input.Engine == "os" {
+				path = "/api/n9e/os-indices"
+			}
+			result, err := client.DoPost[any](c, ctx, path, input.Body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+func listLogFieldsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_log_fields",
+			Description: "List fields for an Elasticsearch (default) or OpenSearch index. Body must include datasource_id and the index name.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Log Fields",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"body"},
+				Properties: map[string]*jsonschema.Schema{
+					"body":   {Type: "object"},
+					"engine": {Type: "string", Description: "'es' (default) or 'os' for OpenSearch"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input logIndicesInput) (*mcp.CallToolResult, error) {
+			if len(input.Body) == 0 {
+				return toolset.NewToolResultError("body is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			path := "/api/n9e/fields"
+			if input.Engine == "os" {
+				path = "/api/n9e/os-fields"
+			}
+			result, err := client.DoPost[any](c, ctx, path, input.Body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/n9e/n9e-mcp-server/pkg/client"
+	"github.com/n9e/n9e-mcp-server/pkg/toolset"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// defaultMaxPoints caps how many time-series points a range query may return per series
+// before downsampling. Models tend to choke (and burn tokens) on tens of thousands of points.
+const defaultMaxPoints = 1000
+
+// RegisterMetricsToolset registers the metrics-query toolset.
+// Tools wrap n9e's path-agnostic datasource proxy at /api/n9e/proxy/{ds_id}/*url
+// to expose Prometheus-compatible queries (instant, range, label_values, series).
+func RegisterMetricsToolset(group *toolset.ToolsetGroup, getClient client.GetClientFunc) {
+	ts := toolset.NewToolset("metrics", "Metrics query tools (Prometheus-compatible) via n9e datasource proxy")
+
+	ts.AddReadTools(
+		queryInstantTool(getClient),
+		queryRangeTool(getClient),
+		queryLabelValuesTool(getClient),
+		querySeriesTool(getClient),
+	)
+
+	group.AddToolset(ts)
+}
+
+type queryInstantInput struct {
+	DsId  int64   `json:"ds_id"`
+	Query string  `json:"query"`
+	Time  float64 `json:"time,omitempty"`
+}
+
+func queryInstantTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "query_instant",
+			Description: "Run a Prometheus instant query (PromQL) against a datasource via n9e proxy.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Prometheus Instant Query",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"ds_id", "query"},
+				Properties: map[string]*jsonschema.Schema{
+					"ds_id": {Type: "integer", Description: "Datasource ID"},
+					"query": {Type: "string", Description: "PromQL expression"},
+					"time":  {Type: "number", Description: "Optional evaluation time (Unix seconds)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input queryInstantInput) (*mcp.CallToolResult, error) {
+			if input.DsId <= 0 {
+				return toolset.NewToolResultError("ds_id is required"), nil
+			}
+			if input.Query == "" {
+				return toolset.NewToolResultError("query is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			params := url.Values{}
+			params.Set("query", input.Query)
+			if input.Time > 0 {
+				params.Set("time", strconv.FormatFloat(input.Time, 'f', -1, 64))
+			}
+
+			path := fmt.Sprintf("/api/n9e/proxy/%d/api/v1/query", input.DsId)
+			result, err := client.DoGet[any](c, ctx, path, params)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+type queryRangeInput struct {
+	DsId      int64   `json:"ds_id"`
+	Query     string  `json:"query"`
+	Start     float64 `json:"start"`
+	End       float64 `json:"end"`
+	Step      float64 `json:"step,omitempty"`
+	MaxPoints int     `json:"max_points,omitempty"`
+}
+
+func queryRangeTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "query_range",
+			Description: "Run a Prometheus range query against a datasource. The 'step' is auto-adjusted upward when the result would exceed max_points (default 1000) per series, and 'truncated' is set in the response.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Prometheus Range Query",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"ds_id", "query", "start", "end"},
+				Properties: map[string]*jsonschema.Schema{
+					"ds_id":      {Type: "integer", Description: "Datasource ID"},
+					"query":      {Type: "string", Description: "PromQL expression"},
+					"start":      {Type: "number", Description: "Start time (Unix seconds)"},
+					"end":        {Type: "number", Description: "End time (Unix seconds)"},
+					"step":       {Type: "number", Description: "Resolution step in seconds (auto if omitted)"},
+					"max_points": {Type: "integer", Description: "Cap points per series (default 1000)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input queryRangeInput) (*mcp.CallToolResult, error) {
+			if input.DsId <= 0 || input.Query == "" || input.Start <= 0 || input.End <= 0 {
+				return toolset.NewToolResultError("ds_id, query, start, end are required"), nil
+			}
+			if input.End <= input.Start {
+				return toolset.NewToolResultError("end must be > start"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+
+			maxPoints := input.MaxPoints
+			if maxPoints <= 0 {
+				maxPoints = defaultMaxPoints
+			}
+
+			step := input.Step
+			truncated := false
+			if step <= 0 {
+				step = (input.End - input.Start) / float64(maxPoints)
+				if step < 1 {
+					step = 1
+				}
+			}
+			// If user-supplied step would still exceed max_points, bump it.
+			if pts := (input.End - input.Start) / step; pts > float64(maxPoints) {
+				step = (input.End - input.Start) / float64(maxPoints)
+				truncated = true
+			}
+
+			params := url.Values{}
+			params.Set("query", input.Query)
+			params.Set("start", strconv.FormatFloat(input.Start, 'f', -1, 64))
+			params.Set("end", strconv.FormatFloat(input.End, 'f', -1, 64))
+			params.Set("step", strconv.FormatFloat(step, 'f', -1, 64))
+
+			path := fmt.Sprintf("/api/n9e/proxy/%d/api/v1/query_range", input.DsId)
+			result, err := client.DoGet[any](c, ctx, path, params)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+
+			return toolset.MarshalResult(map[string]any{
+				"effective_step": step,
+				"max_points":     maxPoints,
+				"truncated":      truncated,
+				"data":           result,
+			}), nil
+		}),
+	)
+}
+
+type queryLabelValuesInput struct {
+	DsId  int64  `json:"ds_id"`
+	Label string `json:"label"`
+}
+
+func queryLabelValuesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "query_label_values",
+			Description: "List all values seen for a Prometheus label.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Prometheus Label Values",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"ds_id", "label"},
+				Properties: map[string]*jsonschema.Schema{
+					"ds_id": {Type: "integer"},
+					"label": {Type: "string", Description: "Label name (e.g. 'instance')"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input queryLabelValuesInput) (*mcp.CallToolResult, error) {
+			if input.DsId <= 0 || input.Label == "" {
+				return toolset.NewToolResultError("ds_id and label are required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			path := fmt.Sprintf("/api/n9e/proxy/%d/api/v1/label/%s/values", input.DsId, url.PathEscape(input.Label))
+			result, err := client.DoGet[any](c, ctx, path, nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+type querySeriesInput struct {
+	DsId  int64    `json:"ds_id"`
+	Match []string `json:"match"`
+	Start float64  `json:"start,omitempty"`
+	End   float64  `json:"end,omitempty"`
+}
+
+func querySeriesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "query_series",
+			Description: "Find series matching one or more matchers (Prometheus /series).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Prometheus Series",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"ds_id", "match"},
+				Properties: map[string]*jsonschema.Schema{
+					"ds_id": {Type: "integer"},
+					"match": {Type: "array", Items: &jsonschema.Schema{Type: "string"}, Description: "Series selectors, e.g. up{job='node'}"},
+					"start": {Type: "number"},
+					"end":   {Type: "number"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input querySeriesInput) (*mcp.CallToolResult, error) {
+			if input.DsId <= 0 || len(input.Match) == 0 {
+				return toolset.NewToolResultError("ds_id and match are required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			params := url.Values{}
+			for _, m := range input.Match {
+				params.Add("match[]", m)
+			}
+			if input.Start > 0 {
+				params.Set("start", strconv.FormatFloat(input.Start, 'f', -1, 64))
+			}
+			if input.End > 0 {
+				params.Set("end", strconv.FormatFloat(input.End, 'f', -1, 64))
+			}
+			path := fmt.Sprintf("/api/n9e/proxy/%d/api/v1/series", input.DsId)
+			result, err := client.DoGet[any](c, ctx, path, params)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}

--- a/pkg/api/notify_rules.go
+++ b/pkg/api/notify_rules.go
@@ -23,17 +23,33 @@ type GetNotifyRuleInput struct {
 	RuleId int64 `json:"id"`
 }
 
-// RegisterNotifyRulesToolset registers notification rules toolset
+// RegisterNotifyRulesToolset registers notification rules + channels + templates toolset
 func RegisterNotifyRulesToolset(group *toolset.ToolsetGroup, getClient client.GetClientFunc) {
-	ts := toolset.NewToolset("notify_rules", "Notification rule management tools")
+	ts := toolset.NewToolset("notify_rules", "Notification rule, channel and template management")
 
 	ts.AddReadTools(
 		listNotifyRulesTool(getClient),
 		getNotifyRuleTool(getClient),
+		listNotifyChannelsTool(getClient),
+		getNotifyChannelTool(getClient),
+		listNotifyTemplatesTool(getClient),
+	)
+
+	ts.AddWriteTools(
+		createNotifyRulesTool(getClient),
+		updateNotifyRuleTool(getClient),
+		testNotifyRuleTool(getClient),
+		createNotifyChannelTool(getClient),
+		updateNotifyChannelTool(getClient),
+		createNotifyTemplateTool(getClient),
+		updateNotifyTemplateTool(getClient),
+		updateNotifyTemplateContentTool(getClient),
 	)
 
 	group.AddToolset(ts)
 }
+
+// --- Read tools ---
 
 func listNotifyRulesTool(getClient client.GetClientFunc) toolset.ServerTool {
 	return toolset.NewServerTool(
@@ -47,14 +63,8 @@ func listNotifyRulesTool(getClient client.GetClientFunc) toolset.ServerTool {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
-					"limit": {
-						Type:        "integer",
-						Description: "Page size (default 20)",
-					},
-					"p": {
-						Type:        "integer",
-						Description: "Page number (starts from 1)",
-					},
+					"limit": {Type: "integer", Description: "Page size (default 20)"},
+					"p":     {Type: "integer", Description: "Page number (starts from 1)"},
 				},
 			},
 		},
@@ -63,12 +73,10 @@ func listNotifyRulesTool(getClient client.GetClientFunc) toolset.ServerTool {
 			if c == nil {
 				return toolset.NewToolResultError("failed to get n9e client from context"), nil
 			}
-
 			result, err := client.DoGet[[]types.NotifyRule](c, ctx, "/api/n9e/notify-rules", nil)
 			if err != nil {
 				return toolset.NewToolResultError(err.Error()), nil
 			}
-
 			items, total := toolset.SlicePage(result, input.Page, input.Limit)
 			return toolset.MarshalResult(types.PageResp[types.NotifyRule]{List: items, Total: total}), nil
 		}),
@@ -88,10 +96,7 @@ func getNotifyRuleTool(getClient client.GetClientFunc) toolset.ServerTool {
 				Type:     "object",
 				Required: []string{"id"},
 				Properties: map[string]*jsonschema.Schema{
-					"id": {
-						Type:        "integer",
-						Description: "Notification rule ID",
-					},
+					"id": {Type: "integer", Description: "Notification rule ID"},
 				},
 			},
 		},
@@ -99,19 +104,410 @@ func getNotifyRuleTool(getClient client.GetClientFunc) toolset.ServerTool {
 			if input.RuleId <= 0 {
 				return toolset.NewToolResultError("id is required and must be positive"), nil
 			}
-
 			c := getClient(ctx)
 			if c == nil {
 				return toolset.NewToolResultError("failed to get n9e client from context"), nil
 			}
-
-			path := fmt.Sprintf("/api/n9e/notify-rule/%d", input.RuleId)
-			result, err := client.DoGet[types.NotifyRule](c, ctx, path, nil)
+			result, err := client.DoGet[types.NotifyRule](c, ctx, fmt.Sprintf("/api/n9e/notify-rule/%d", input.RuleId), nil)
 			if err != nil {
 				return toolset.NewToolResultError(err.Error()), nil
 			}
-
 			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+func listNotifyChannelsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_notify_channels",
+			Description: "List all notification channel configurations (full payload — admin perspective)",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Notify Channels",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{Type: "object"},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoGet[[]map[string]any](c, ctx, "/api/n9e/notify-channel-configs", nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+type getByIDInput struct {
+	Id int64 `json:"id"`
+}
+
+func getNotifyChannelTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "get_notify_channel",
+			Description: "Get a single notification channel configuration by ID",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Notify Channel",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id"},
+				Properties: map[string]*jsonschema.Schema{
+					"id": {Type: "integer", Description: "Notification channel ID"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input getByIDInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 {
+				return toolset.NewToolResultError("id is required and must be positive"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoGet[map[string]any](c, ctx, fmt.Sprintf("/api/n9e/notify-channel-config/%d", input.Id), nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+func listNotifyTemplatesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_notify_templates",
+			Description: "List all notification templates",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Notify Templates",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{Type: "object"},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoGet[[]map[string]any](c, ctx, "/api/n9e/notify-tpls", nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+// --- Write tools ---
+
+type createNotifyRulesInput struct {
+	Rules []map[string]any `json:"rules"`
+}
+
+func createNotifyRulesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "create_notify_rules",
+			Description: "Create one or more notification rules (n9e endpoint accepts an array)",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create Notify Rules",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"rules"},
+				Properties: map[string]*jsonschema.Schema{
+					"rules": {
+						Type:        "array",
+						Description: "Notification rule bodies",
+						Items:       &jsonschema.Schema{Type: "object"},
+					},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input createNotifyRulesInput) (*mcp.CallToolResult, error) {
+			if len(input.Rules) == 0 {
+				return toolset.NewToolResultError("rules must be non-empty"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/notify-rules", input.Rules)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result, "created": len(input.Rules)}), nil
+		}),
+	)
+}
+
+type updateNotifyRuleInput struct {
+	Id   int64          `json:"id"`
+	Rule map[string]any `json:"rule"`
+}
+
+func updateNotifyRuleTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_notify_rule",
+			Description: "Update an existing notification rule by ID",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Notify Rule",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id", "rule"},
+				Properties: map[string]*jsonschema.Schema{
+					"id":   {Type: "integer", Description: "Notification rule ID"},
+					"rule": {Type: "object", Description: "Full rule body"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateNotifyRuleInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 {
+				return toolset.NewToolResultError("id is required and must be positive"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/notify-rule/%d", input.Id), input.Rule)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Id, "message": "Notification rule updated"}), nil
+		}),
+	)
+}
+
+type testNotifyRuleInput struct {
+	Body map[string]any `json:"body"`
+}
+
+func testNotifyRuleTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "test_notify_rule",
+			Description: "Send a test notification using the supplied notify-rule body without persisting it.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Test Notify Rule",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"body"},
+				Properties: map[string]*jsonschema.Schema{
+					"body": {Type: "object", Description: "Notification rule body to test (matches n9e's /notify-rule/test payload)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input testNotifyRuleInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/notify-rule/test", input.Body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result}), nil
+		}),
+	)
+}
+
+type createNotifyChannelInput struct {
+	Channel map[string]any `json:"channel"`
+}
+
+func createNotifyChannelTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "create_notify_channel",
+			Description: "Create a notification channel configuration (e.g. webhook, dingtalk, feishu).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create Notify Channel",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"channel"},
+				Properties: map[string]*jsonschema.Schema{
+					"channel": {Type: "object", Description: "Channel configuration body"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input createNotifyChannelInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/notify-channel-configs", input.Channel)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result, "message": "Channel created"}), nil
+		}),
+	)
+}
+
+type updateNotifyChannelInput struct {
+	Id      int64          `json:"id"`
+	Channel map[string]any `json:"channel"`
+}
+
+func updateNotifyChannelTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_notify_channel",
+			Description: "Update an existing notification channel configuration",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Notify Channel",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id", "channel"},
+				Properties: map[string]*jsonschema.Schema{
+					"id":      {Type: "integer"},
+					"channel": {Type: "object"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateNotifyChannelInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 {
+				return toolset.NewToolResultError("id is required and must be positive"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/notify-channel-config/%d", input.Id), input.Channel)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Id, "message": "Channel updated"}), nil
+		}),
+	)
+}
+
+type createNotifyTemplateInput struct {
+	Template map[string]any `json:"template"`
+}
+
+func createNotifyTemplateTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "create_notify_template",
+			Description: "Create a notification template",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create Notify Template",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"template"},
+				Properties: map[string]*jsonschema.Schema{
+					"template": {Type: "object"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input createNotifyTemplateInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/notify-tpl", input.Template)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result}), nil
+		}),
+	)
+}
+
+type updateNotifyTemplateInput struct {
+	Template map[string]any `json:"template"`
+}
+
+func updateNotifyTemplateTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_notify_template",
+			Description: "Update a notification template (full body)",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Notify Template",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"template"},
+				Properties: map[string]*jsonschema.Schema{
+					"template": {Type: "object", Description: "Template body including id"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateNotifyTemplateInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, "/api/n9e/notify-tpl", input.Template)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"message": "Template updated"}), nil
+		}),
+	)
+}
+
+type updateNotifyTemplateContentInput struct {
+	Body map[string]any `json:"body"`
+}
+
+func updateNotifyTemplateContentTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_notify_template_content",
+			Description: "Update only the rendered content of a notification template (lighter than update_notify_template).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Notify Template Content",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"body"},
+				Properties: map[string]*jsonschema.Schema{
+					"body": {Type: "object", Description: "Body matching n9e's /notify-tpl/content payload"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateNotifyTemplateContentInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, "/api/n9e/notify-tpl/content", input.Body)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"message": "Template content updated"}), nil
 		}),
 	)
 }

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -1,0 +1,241 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/n9e/n9e-mcp-server/pkg/client"
+	"github.com/n9e/n9e-mcp-server/pkg/toolset"
+	"github.com/n9e/n9e-mcp-server/pkg/types"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// RegisterRolesToolset registers the roles & operations (RBAC) toolset.
+//
+// Note: in n9e v8 there is no dedicated "assign role to user" endpoint —
+// the user's roles live on the users.roles column and are updated via
+// update_user_profile (see users toolset).
+func RegisterRolesToolset(group *toolset.ToolsetGroup, getClient client.GetClientFunc) {
+	ts := toolset.NewToolset("roles", "Role and permission management (n9e RBAC)")
+
+	ts.AddReadTools(
+		listRolesTool(getClient),
+		listOperationsTool(getClient),
+		listRoleOperationsTool(getClient),
+	)
+
+	ts.AddWriteTools(
+		createRoleTool(getClient),
+		updateRoleTool(getClient),
+		bindRoleOperationsTool(getClient),
+	)
+
+	group.AddToolset(ts)
+}
+
+func listRolesTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_roles",
+			Description: "List all roles defined in the system.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Roles",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{Type: "object"},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoGet[[]types.Role](c, ctx, "/api/n9e/roles", nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+func listOperationsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_operations",
+			Description: "List every operation (permission) the system understands.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Operations",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{Type: "object"},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoGet[any](c, ctx, "/api/n9e/operation", nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+type roleByIDInput struct {
+	Id int64 `json:"id"`
+}
+
+func listRoleOperationsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "list_role_operations",
+			Description: "List operations bound to a specific role.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Role Operations",
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id"},
+				Properties: map[string]*jsonschema.Schema{
+					"id": {Type: "integer", Description: "Role ID"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input roleByIDInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 {
+				return toolset.NewToolResultError("id is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoGet[any](c, ctx, fmt.Sprintf("/api/n9e/role/%d/ops", input.Id), nil)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+type createRoleInput struct {
+	Role map[string]any `json:"role"`
+}
+
+func createRoleTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "create_role",
+			Description: "Create a new role.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create Role",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"role"},
+				Properties: map[string]*jsonschema.Schema{
+					"role": {Type: "object", Description: "Role body (name, note)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input createRoleInput) (*mcp.CallToolResult, error) {
+			if len(input.Role) == 0 {
+				return toolset.NewToolResultError("role body is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/roles", input.Role)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result, "message": "Role created"}), nil
+		}),
+	)
+}
+
+type updateRoleInput struct {
+	Role map[string]any `json:"role"`
+}
+
+func updateRoleTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_role",
+			Description: "Update a role's metadata (PUT /roles).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Role",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"role"},
+				Properties: map[string]*jsonschema.Schema{
+					"role": {Type: "object", Description: "Role body including id"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateRoleInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, "/api/n9e/roles", input.Role)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"message": "Role updated"}), nil
+		}),
+	)
+}
+
+type bindRoleOperationsInput struct {
+	Id  int64    `json:"id"`
+	Ops []string `json:"ops"`
+}
+
+func bindRoleOperationsTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "bind_role_operations",
+			Description: "Replace the operations bound to a role (PUT /role/{id}/ops). Send the full ops list, not a delta.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Bind Role Operations",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id", "ops"},
+				Properties: map[string]*jsonschema.Schema{
+					"id":  {Type: "integer", Description: "Role ID"},
+					"ops": {Type: "array", Items: &jsonschema.Schema{Type: "string"}, Description: "Operation names"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input bindRoleOperationsInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 {
+				return toolset.NewToolResultError("id is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/role/%d/ops", input.Id), map[string]any{"ops": input.Ops})
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Id, "ops_count": len(input.Ops)}), nil
+		}),
+	)
+}
+

--- a/pkg/api/tools.go
+++ b/pkg/api/tools.go
@@ -19,6 +19,10 @@ func DefaultToolsetGroup(getClient client.GetClientFunc, readOnly bool) *toolset
 	RegisterAlertSubscribesToolset(group, getClient)
 	RegisterEventPipelinesToolset(group, getClient)
 	RegisterUsersToolset(group, getClient)
+	RegisterMetricsToolset(group, getClient)
+	RegisterLogsToolset(group, getClient)
+	RegisterDashboardsToolset(group, getClient)
+	RegisterRolesToolset(group, getClient)
 
 	return group
 }

--- a/pkg/api/users.go
+++ b/pkg/api/users.go
@@ -48,6 +48,15 @@ func RegisterUsersToolset(group *toolset.ToolsetGroup, getClient client.GetClien
 		getUserGroupTool(getClient),
 	)
 
+	ts.AddWriteTools(
+		createUserTool(getClient),
+		updateUserProfileTool(getClient),
+		resetUserPasswordTool(getClient),
+		createUserGroupTool(getClient),
+		updateUserGroupTool(getClient),
+		addUserGroupMembersTool(getClient),
+	)
+
 	group.AddToolset(ts)
 }
 
@@ -230,6 +239,247 @@ func getUserGroupTool(getClient client.GetClientFunc) toolset.ServerTool {
 			}
 
 			return toolset.MarshalResult(result), nil
+		}),
+	)
+}
+
+// --- Write tools ---
+
+type createUserInput struct {
+	User map[string]any `json:"user"`
+}
+
+func createUserTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "create_user",
+			Description: "Create a new user. The body should at minimum include username, password, and roles.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create User",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"user"},
+				Properties: map[string]*jsonschema.Schema{
+					"user": {Type: "object", Description: "User body (username, password, roles, email, phone, ...)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input createUserInput) (*mcp.CallToolResult, error) {
+			if len(input.User) == 0 {
+				return toolset.NewToolResultError("user body is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/users", input.User)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result, "message": "User created"}), nil
+		}),
+	)
+}
+
+type updateUserProfileInput struct {
+	Id      int64          `json:"id"`
+	Profile map[string]any `json:"profile"`
+}
+
+func updateUserProfileTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_user_profile",
+			Description: "Update a user's profile. The 'roles' field on the body assigns roles to the user (n9e v8 stores roles on the user row, no dedicated assign endpoint).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update User Profile",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id", "profile"},
+				Properties: map[string]*jsonschema.Schema{
+					"id":      {Type: "integer", Description: "User ID"},
+					"profile": {Type: "object", Description: "Profile body (nickname, email, phone, roles, ...)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateUserProfileInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 {
+				return toolset.NewToolResultError("id is required and must be positive"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/user/%d/profile", input.Id), input.Profile)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Id, "message": "Profile updated"}), nil
+		}),
+	)
+}
+
+type resetUserPasswordInput struct {
+	Id       int64  `json:"id"`
+	Password string `json:"password"`
+}
+
+func resetUserPasswordTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "reset_user_password",
+			Description: "Reset a user's password. Requires admin privileges on the n9e side.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Reset User Password",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id", "password"},
+				Properties: map[string]*jsonschema.Schema{
+					"id":       {Type: "integer"},
+					"password": {Type: "string", Description: "New password (will be hashed by n9e)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input resetUserPasswordInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 || input.Password == "" {
+				return toolset.NewToolResultError("id and password are required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/user/%d/password", input.Id), map[string]any{"password": input.Password})
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Id, "message": "Password reset"}), nil
+		}),
+	)
+}
+
+type createUserGroupInput struct {
+	Group map[string]any `json:"group"`
+}
+
+func createUserGroupTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "create_user_group",
+			Description: "Create a new user group (team).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create User Group",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"group"},
+				Properties: map[string]*jsonschema.Schema{
+					"group": {Type: "object", Description: "Group body (name, note, ...)"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input createUserGroupInput) (*mcp.CallToolResult, error) {
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			result, err := client.DoPost[any](c, ctx, "/api/n9e/user-groups", input.Group)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"result": result, "message": "User group created"}), nil
+		}),
+	)
+}
+
+type updateUserGroupInput struct {
+	Id    int64          `json:"id"`
+	Group map[string]any `json:"group"`
+}
+
+func updateUserGroupTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "update_user_group",
+			Description: "Update a user group's metadata (name, note).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update User Group",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id", "group"},
+				Properties: map[string]*jsonschema.Schema{
+					"id":    {Type: "integer"},
+					"group": {Type: "object"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input updateUserGroupInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 {
+				return toolset.NewToolResultError("id is required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPut[any](c, ctx, fmt.Sprintf("/api/n9e/user-group/%d", input.Id), input.Group)
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"id": input.Id, "message": "Group updated"}), nil
+		}),
+	)
+}
+
+type userGroupMembersInput struct {
+	Id  int64   `json:"id"`
+	Ids []int64 `json:"ids"`
+}
+
+func addUserGroupMembersTool(getClient client.GetClientFunc) toolset.ServerTool {
+	return toolset.NewServerTool(
+		mcp.Tool{
+			Name:        "add_user_group_members",
+			Description: "Add user(s) to a user group.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Add User Group Members",
+				ReadOnlyHint:    false,
+				DestructiveHint: toolset.BoolPtr(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id", "ids"},
+				Properties: map[string]*jsonschema.Schema{
+					"id":  {Type: "integer", Description: "User group ID"},
+					"ids": {Type: "array", Items: &jsonschema.Schema{Type: "integer"}, Description: "User IDs to add"},
+				},
+			},
+		},
+		toolset.MakeToolHandler(func(ctx context.Context, req *mcp.CallToolRequest, input userGroupMembersInput) (*mcp.CallToolResult, error) {
+			if input.Id <= 0 || len(input.Ids) == 0 {
+				return toolset.NewToolResultError("id and ids are required"), nil
+			}
+			c := getClient(ctx)
+			if c == nil {
+				return toolset.NewToolResultError("failed to get n9e client from context"), nil
+			}
+			_, err := client.DoPost[any](c, ctx, fmt.Sprintf("/api/n9e/user-group/%d/members", input.Id), map[string]any{"ids": input.Ids})
+			if err != nil {
+				return toolset.NewToolResultError(err.Error()), nil
+			}
+			return toolset.MarshalResult(map[string]any{"added": len(input.Ids)}), nil
 		}),
 	)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -104,6 +104,16 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 
 // makeRequest is the request method with timeout and retry
 func (c *Client) makeRequest(ctx context.Context, method, path string, params url.Values, body any) ([]byte, int, string, error) {
+	return c.makeRequestLimited(ctx, method, path, params, body, maxResponseSize)
+}
+
+// makeRequestLimited is like makeRequest but with a caller-supplied response size cap.
+// A value <= 0 falls back to the default maxResponseSize.
+func (c *Client) makeRequestLimited(ctx context.Context, method, path string, params url.Values, body any, maxSize int64) ([]byte, int, string, error) {
+	if maxSize <= 0 {
+		maxSize = maxResponseSize
+	}
+
 	var lastErr error
 
 	for attempt := 0; attempt <= DefaultMaxRetries; attempt++ {
@@ -130,7 +140,7 @@ func (c *Client) makeRequest(ctx context.Context, method, path string, params ur
 		defer resp.Body.Close()
 
 		// Read response
-		bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+		bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxSize))
 		if err != nil {
 			return nil, 0, "", fmt.Errorf("failed to read response: %w", err)
 		}
@@ -223,6 +233,40 @@ func DoGet[T any](c *Client, ctx context.Context, path string, params url.Values
 	}
 
 	// Check business error
+	if resp.Err != "" {
+		return zero, &APIError{
+			Method:     "GET",
+			Path:       path,
+			Params:     params,
+			StatusCode: httpStatus,
+			ErrMsg:     resp.Err,
+			RequestID:  requestID,
+		}
+	}
+
+	return resp.Dat, nil
+}
+
+// DoGetLarge is like DoGet but accepts an explicit response size cap.
+// Use this for endpoints that legitimately return more than the default 10MB
+// (e.g. dashboard configs, alert rule dumps). A maxSize <= 0 falls back to the default.
+func DoGetLarge[T any](c *Client, ctx context.Context, path string, params url.Values, maxSize int64) (T, error) {
+	var zero T
+
+	bodyBytes, httpStatus, requestID, err := c.makeRequestLimited(ctx, "GET", path, params, nil, maxSize)
+	if err != nil {
+		return zero, err
+	}
+
+	var resp types.N9eResponse[T]
+	if err := json.Unmarshal(bodyBytes, &resp); err != nil {
+		preview := string(bodyBytes)
+		if len(preview) > 200 {
+			preview = preview[:200] + "..."
+		}
+		return zero, fmt.Errorf("failed to unmarshal response (check N9E_BASE_URL and N9E_TOKEN): %w, response preview: %s", err, preview)
+	}
+
 	if resp.Err != "" {
 		return zero, &APIError{
 			Method:     "GET",

--- a/pkg/toolset/toolsets.go
+++ b/pkg/toolset/toolsets.go
@@ -10,7 +10,11 @@ import (
 )
 
 // DefaultToolsets is the default enabled toolsets
-var DefaultToolsets = []string{"alerts", "targets", "datasource", "mutes", "busi_groups", "notify_rules", "alert_subscribes", "event_pipelines", "users"}
+var DefaultToolsets = []string{
+	"alerts", "targets", "datasource", "mutes", "busi_groups",
+	"notify_rules", "alert_subscribes", "event_pipelines", "users",
+	"metrics", "logs", "dashboards", "roles",
+}
 
 // ServerTool wraps MCP tool and its handler function
 type ServerTool struct {
@@ -26,7 +30,10 @@ func NewServerTool(tool mcp.Tool, handler mcp.ToolHandler) ServerTool {
 	}
 }
 
-// Toolset represents a toolset
+// Toolset represents a toolset.
+// Tools split into two safety tiers:
+//   - ReadTools: always registered.
+//   - WriteTools: registered unless the group is in read-only mode.
 type Toolset struct {
 	Name        string
 	Description string
@@ -50,7 +57,7 @@ func (t *Toolset) AddReadTools(tools ...ServerTool) *Toolset {
 	return t
 }
 
-// AddWriteTools adds write tools
+// AddWriteTools adds write tools (create/update)
 func (t *Toolset) AddWriteTools(tools ...ServerTool) *Toolset {
 	t.WriteTools = append(t.WriteTools, tools...)
 	return t
@@ -104,25 +111,26 @@ func (g *ToolsetGroup) EnableToolsets(names []string) error {
 	return nil
 }
 
-// RegisterAll registers all enabled tools to MCP Server
+// RegisterAll registers all enabled tools to MCP Server.
+// Read tools are always registered. Write tools are skipped when readOnly=true.
 func (g *ToolsetGroup) RegisterAll(s *mcp.Server) {
 	for name, toolset := range g.toolsets {
 		if !g.enabled[name] {
 			continue
 		}
 
-		// Register read-only tools
 		for _, st := range toolset.ReadTools {
 			tool := st.Tool
 			s.AddTool(&tool, st.Handler)
 		}
 
-		// If not read-only mode, register write tools
-		if !g.readOnly {
-			for _, st := range toolset.WriteTools {
-				tool := st.Tool
-				s.AddTool(&tool, st.Handler)
-			}
+		if g.readOnly {
+			continue
+		}
+
+		for _, st := range toolset.WriteTools {
+			tool := st.Tool
+			s.AddTool(&tool, st.Handler)
 		}
 	}
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -437,3 +437,38 @@ type PeriodicMute struct {
 	EnableEtime      string `json:"enable_etime"`
 	EnableDaysOfWeek string `json:"enable_days_of_week"`
 }
+
+// Board represents a dashboard. The panel JSON lives in Configs and can be very large;
+// the dashboards toolset uses DoGetLarge when fetching it for backup.
+type Board struct {
+	Id        int64    `json:"id"`
+	GroupId   int64    `json:"group_id"`
+	Name      string   `json:"name"`
+	Ident     string   `json:"ident,omitempty"`
+	Tags      string   `json:"tags,omitempty"`
+	BuiltIn   int      `json:"built_in,omitempty"`
+	Hide      int      `json:"hide,omitempty"`
+	Public    int      `json:"public,omitempty"`
+	PublicCate int     `json:"public_cate,omitempty"`
+	Bgids     []int64  `json:"bgids,omitempty"`
+	CreateAt  int64    `json:"create_at"`
+	CreateBy  string   `json:"create_by"`
+	UpdateAt  int64    `json:"update_at"`
+	UpdateBy  string   `json:"update_by"`
+	Configs   string   `json:"configs,omitempty"` // JSON string of panels
+}
+
+// Role represents an RBAC role definition.
+type Role struct {
+	Id    int64  `json:"id"`
+	Name  string `json:"name"`
+	Note  string `json:"note,omitempty"`
+	Extra any    `json:"extra,omitempty"`
+}
+
+// Operation represents a permission operation that may be bound to a role.
+type Operation struct {
+	Name  string `json:"name"`
+	Group string `json:"group,omitempty"`
+	Cn    string `json:"cn,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Add **write tools** (create/update/import/clone/toggle) for alert rules, notification rules/channels/templates, datasources, and users/user-groups.
- New toolsets:
  - `dashboards` — full CRUD + clone, with `get_dashboard_pure` lifting the response cap to 64MB for large panel JSON.
  - `roles` — RBAC role and operation management. Note: in n9e v8 user→role assignment lives on `users.roles` (no dedicated endpoint), so it's done via `update_user_profile`.
  - `metrics` — Prometheus query proxy via the path-agnostic `/api/n9e/proxy/{ds_id}/api/v1/*`. `query_range` auto-adjusts `step` so a single series never returns more than `max_points`
(default 1000), and flags `truncated:true` when downsampled.
  - `logs` — Plugin-dispatched `/logs-query` covering Loki/ES/OS in one tool. Default `limit=200`; rejects time ranges > 7 days.
- **Two-tier safety model**: read tools always available; all write tools gated behind `--read-only`. **No delete/destructive operations are exposed** — intentionally out of scope.
- Endpoint paths were ground-truthed against `ccfos/nightingale@main` (`center/router/router.go` + handlers) so they match real v8 routes (e.g. datasource is POST-only with shared
`/upsert`; alert rule enable/disable goes through `PUT .../alert-rules/fields`; notify rule create takes an array).

Default toolset list grows from 9 → 13: `alerts, targets, datasource, mutes, busi_groups, notify_rules, alert_subscribes, event_pipelines, users, metrics, logs, dashboards, roles`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] stdio probe verifies tool counts per tier:
  - `--read-only`: 44 unique tools (read only)
  - default: 76 unique tools (read + write)
  - in default mode, no `delete_*` / `dump_*` / `restore_*` / `list_backups` tools appear
- [x] `--help` shows extended `N9E_TOOLSETS` default with the new toolset names
- [ ] Per-toolset round-trip against a dev n9e instance (recommended before merge):
  - `alert_rules`: create → toggle disable → import_prom (sample rule)
  - `dashboards`: create → update_panels → clone
  - `notify_rules`: full triplet (rule + channel + template) create → test
  - `datasource`: upsert (Prometheus) → list_full → status_update
  - `users` + `roles`: create role → create user with role → reset password
  - `metrics`: range query — verify `truncated:true` when result > 1000 points
  - `logs`: query against ES/Loki test datasource
